### PR TITLE
CA-82314: networkd: introduce Linklocal6 IPv6 address mode

### DIFF
--- a/network/network_interface.ml
+++ b/network/network_interface.ml
@@ -72,7 +72,7 @@ type port = string
 type bridge = string
 type dhcp_options = [`set_gateway | `set_dns]
 type ipv4 = None4 | DHCP4 | Static4 of (Unix.inet_addr * int) list
-type ipv6 = None6 | DHCP6 | Autoconf6 | Static6 of (Unix.inet_addr * int) list
+type ipv6 = None6 | Linklocal6 | DHCP6 | Autoconf6 | Static6 of (Unix.inet_addr * int) list
 
 type duplex = Duplex_unknown | Duplex_half | Duplex_full
 


### PR DESCRIPTION
This commit redefines the IPv6 address mode "None6" to mean "no IPv6 address at
all, not even a link local one", and introduces the new mode Linklocal6, which
means "only IPv6 address, except a link local one".

Signed-off-by: Rob Hoes rob.hoes@citrix.com
Imported-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
