### PR TITLE
CA-114333: Allow Linux HVM guests to use >4 devices.

### DIFF
--- a/xen/device_number.ml
+++ b/xen/device_number.ml
@@ -165,7 +165,7 @@ let to_disk_number = function
 	| Ide, disk, _ -> disk
 
 let of_disk_number hvm n = 
-	if hvm && (n < 16)
+	if hvm && (n < 4)
 	then Ide, n, 0
 	else Xen, n, 0
 


### PR DESCRIPTION
Windows PV drivers don't check the guest device name, but the Linux kernel does
With devices > 4, Linux expects them to be in xvdN format, so this patch ensures
that all devices are treated as Linux devices.
