### PR TITLE
CA-141526: Putting VBD path to /dev/xvdX for HVM guests

### DIFF
--- a/xen/device_number.ml
+++ b/xen/device_number.ml
@@ -112,7 +112,7 @@ let to_linux_device =
 	function
 		| Xen,  disk, part -> Printf.sprintf "xvd%s%s" (string_of_int26 disk) (p part)
 		| Scsi, disk, part -> Printf.sprintf "sd%s%s"  (string_of_int26 disk) (p part)
-		| Ide,  disk, part -> Printf.sprintf "hd%s%s"  (string_of_int26 disk) (p part)
+		| Ide,  disk, part -> Printf.sprintf "xvd%s%s"  (string_of_int26 disk) (p part)
 
 let of_linux_device x =
 	let letter c = 'a' <= c && (c <= 'z') in


### PR DESCRIPTION
/dev/hda is anyways meaningless for HVM guest.So, we always populate the
VBD path to be /dev/xvdX.

Imported from xen-api.git fc5108344c12a735398a050ae39b6ddf39d98dd0

Signed-off-by: Ravi Pandey ravi.pandey@citrix.com
Imported-by: John Else john.else@citrix.com
