### PR TITLE
[RFC] xen: Add a "floppy" type, alongside cdrom and hard disk (take #2)

### DIFF
--- a/xen/device_number.ml
+++ b/xen/device_number.ml
@@ -1,6 +1,7 @@
 type bus_type =
 	| Xen 
 	| Scsi
+	| Floppy
 	| Ide
 with rpc
 
@@ -9,9 +10,10 @@ type spec = bus_type * int * int with rpc
 type t = spec with rpc
 
 let to_debug_string = function
-	| (Xen, disk, partition)  -> Printf.sprintf "Xen(%d, %d)"  disk partition
-	| (Scsi, disk, partition) -> Printf.sprintf "Scsi(%d, %d)" disk partition
-	| (Ide, disk, partition)  -> Printf.sprintf "Ide(%d, %d)"  disk partition
+	| (Xen,    disk, partition) -> Printf.sprintf "Xen(%d, %d)"    disk partition
+	| (Scsi,   disk, partition) -> Printf.sprintf "Scsi(%d, %d)"   disk partition
+	| (Floppy, disk, partition) -> Printf.sprintf "Floppy(%d, %d)" disk partition
+	| (Ide   , disk, partition) -> Printf.sprintf "Ide(%d, %d)"    disk partition
 
 (* ocamlp4-friendly operators *)
 let (<|) = (lsl)
@@ -26,15 +28,17 @@ let make (x: spec) : t =
 	let max_xen = ((1 <| 20) - 1), 15 in
 	let max_scsi = 15, 15 in
 	let max_ide = if use_deprecated_ide_encoding then 19, 63 else 3, 63 in
+	let max_floppy = 2, 0 in
 	let assert_in_range description (disk_limit, partition_limit) (disk, partition) = 
 		if disk < 0 || (disk > disk_limit) 
 		then failwith (Printf.sprintf "%s disk number out of range 0 <= %d <= %d" description disk disk_limit);
 		if partition < 0 || partition > partition_limit 
 		then failwith (Printf.sprintf "%s partition number out of range 0 <= %d <= %d" description partition partition_limit) in
 	begin match x with
-		| Xen, disk, partition -> assert_in_range "xen" max_xen (disk, partition)
-		| Scsi, disk, partition -> assert_in_range "scsi" max_scsi (disk, partition)
-		| Ide, disk, partition -> assert_in_range "ide" max_ide (disk, partition)
+		| Xen,    disk, partition -> assert_in_range "xen" max_xen (disk, partition)
+		| Scsi,   disk, partition -> assert_in_range "scsi" max_scsi (disk, partition)
+		| Floppy, disk, partition -> assert_in_range "floppy" max_floppy (disk, partition)
+		| Ide,    disk, partition -> assert_in_range "ide" max_ide (disk, partition)
 	end;
 	x
 
@@ -46,10 +50,11 @@ let standard_ide_table = [ 3; 22 ]
 let deprecated_ide_table = standard_ide_table @ [ 33; 34; 56; 57; 88; 89; 90; 91 ]
 
 let to_xenstore_int = function
-	| Xen, disk, partition when disk < 16 -> (202 <| 8) || (disk <| 4)       || partition
-	| Xen, disk, partition                -> (1 <| 28)  || (disk <| 8)       || partition
-	| Scsi, disk, partition               -> (8 <| 8)   || (disk <| 4)       || partition
-	| Ide, disk, partition                ->
+	| Xen,    disk, partition when disk < 16 -> (202 <| 8) || (disk <| 4) || partition
+	| Xen,    disk, partition                -> (1 <| 28)  || (disk <| 8) || partition
+	| Scsi,   disk, partition                -> (8 <| 8)   || (disk <| 4) || partition
+	| Floppy, disk, partition                -> (203 <| 8) || (disk <| 4) || partition
+	| Ide,    disk, partition                ->
 		let m = List.nth deprecated_ide_table (disk / 2) in
 		let n = disk - (disk / 2) * 2 in (* NB integers behave differently to reals *)
 		(m <| 8) || (n <| 6) || partition
@@ -60,8 +65,9 @@ let of_xenstore_int x =
 	if (x && (1 <| 28)) <> 0
 	then Xen, (x >| 8) && ((1 <| 20) - 1), x && ((1 <| 8) - 1)
 	else match x >| 8 with
-		| 202 -> Xen, (x >| 4) && ((1 <| 4) - 1), x && ((1 <| 4) - 1)
-		| 8   -> Scsi, (x >| 4) && ((1 <| 4) - 1), x && ((1 <| 4) - 1)
+		| 202 -> Xen,    (x >| 4) && ((1 <| 4) - 1), x && ((1 <| 4) - 1)
+		| 8   -> Scsi,   (x >| 4) && ((1 <| 4) - 1), x && ((1 <| 4) - 1)
+		| 203 -> Floppy, (x >| 4) && ((1 <| 4) - 1), x && ((1 <| 4) - 1)
 		| n   ->
 			let idx = snd(List.fold_left (fun (i, res) e -> i+1, if e = n then i else res) (0, -1) deprecated_ide_table) in
 			if idx < 0
@@ -110,9 +116,10 @@ let int26_of_string x =
 let to_linux_device = 
 	let p x = if x = 0 then "" else string_of_int x in 
 	function
-		| Xen,  disk, part -> Printf.sprintf "xvd%s%s" (string_of_int26 disk) (p part)
-		| Scsi, disk, part -> Printf.sprintf "sd%s%s"  (string_of_int26 disk) (p part)
-		| Ide,  disk, part -> Printf.sprintf "xvd%s%s"  (string_of_int26 disk) (p part)
+		| Xen,    disk, part -> Printf.sprintf "xvd%s%s" (string_of_int26 disk) (p part)
+		| Scsi,   disk, part -> Printf.sprintf "sd%s%s"  (string_of_int26 disk) (p part)
+		| Floppy, disk, part -> Printf.sprintf "fd%s%s"  (string_of_int26 disk) (p part)
+		| Ide,    disk, part -> Printf.sprintf "xvd%s%s" (string_of_int26 disk) (p part)
 
 let of_linux_device x =
 	let letter c = 'a' <= c && (c <= 'z') in
@@ -149,6 +156,9 @@ let of_linux_device x =
 		| 's' :: 'd' :: rest ->
 			let disk, partition = parse_b26_int rest in
 			Scsi, disk, partition
+		| 'f' :: 'd' :: rest ->
+			let disk, partition = parse_b26_int rest in
+			Floppy, disk, partition
 		| 'h' :: 'd' :: rest ->
 			let disk, partition = parse_b26_int rest in
 			Ide, disk, partition
@@ -167,6 +177,7 @@ type disk_number = int
 let to_disk_number = function
 	| Xen, disk, _ -> disk
 	| Scsi, disk, _ -> disk
+	| Floppy, disk, _ -> disk
 	| Ide, disk, _ -> disk
 
 let of_disk_number hvm n = 

--- a/xen/device_number.mli
+++ b/xen/device_number.mli
@@ -1,8 +1,9 @@
 (** Disks are attached to particular bus types: *)
 type bus_type =
-	| Xen  (** A xen paravirtualised bus *)
-	| Scsi (** A SCSI bus *)
-	| Ide  (** An IDE bus *)
+	| Xen    (** A xen paravirtualised bus *)
+	| Scsi   (** A SCSI bus *)
+	| Floppy (** A floppy bus *)
+	| Ide    (** An IDE bus *)
 
 (** A specification for a device number. There are more valid specifications than
     valid device numbers because of hardware and/or protocol limits. *)

--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -250,7 +250,7 @@ module Vbd = struct
 
 	type mode = ReadOnly | ReadWrite
 
-	type ty = CDROM | Disk
+	type ty = CDROM | Disk | Floppy
 
 	type id = string * string
 


### PR DESCRIPTION
Original pull request: https://github.com/xapi-project/xcp-idl/pull/46
Updated with a new floppy bus type, as qemu wants floppy drives to be on the "floppy" bus, rather than "ide".

Note that this means that `Device_number.to_disk_number` is no longer unique (e.g. "fda" and "xvda" are both disk number "0"), and should not be used to identify disks. [This is the subject of a bugfix in xen-api -- see pull request https://github.com/xapi-project/xen-api/pull/2068]