### PR TITLE
CP-9895: Added originator for xapi login_with_password

### DIFF
--- a/xen-api-plugin/service.md
+++ b/xen-api-plugin/service.md
@@ -44,7 +44,7 @@ Client applications who wish to invoke operations on this custom service
 should first use the XenAPI to acquire a valid *session_id*, for example
 using the XenAPI
 
-    session.login_with_password(username, password)
+    session.login_with_password(username, password, version, originator)
 
 Once a valid session_id has been acquired, a client may issue
   1. HTTP GET


### PR DESCRIPTION
The login_with_password XenAPI call takes an "originator"
string as its fourth parameter.

If a client does this, then it gets its own pool of xapi sessions.
Moreover it will not have its xapi sessions destroyed prematurely
as a result of some other misbehaving client that keeps creating
sessions and not logging out of them.

This patch adds the "originator" to all invokes of
login_with_password.

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>