### PR TITLE
storage: add set_name_label and set_name_description

### DIFF
--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -294,6 +294,12 @@ module VDI = struct
         returns the vdi_info which was used. *)
 	external create : dbg:debug_info -> sr:sr -> vdi_info:vdi_info -> vdi_info = ""
 
+	(** [set_name_label sr vdi new_name_label] updates the name_label of VDI [vdi] in SR [sr]. *)
+	external set_name_label : dbg:debug_info -> sr:sr -> vdi:vdi -> new_name_label:string -> unit = ""
+
+	(** [set_name_description sr vdi new_name_description] updates the name_description of VDI [vdi] in SR [sr]. *)
+	external set_name_description : dbg:debug_info -> sr:sr -> vdi:vdi -> new_name_description:string -> unit = ""
+
 	(** [snapshot task sr vdi_info] creates a new VDI which is a snapshot of [vdi_info] in [sr] *)
 	external snapshot : dbg:debug_info -> sr:sr -> vdi_info:vdi_info -> vdi_info = ""
 

--- a/storage/storage_skeleton.ml
+++ b/storage/storage_skeleton.ml
@@ -52,6 +52,8 @@ end
 
 module VDI = struct
   let create ctx ~dbg ~sr ~vdi_info = u "VDI.create"
+  let set_name_label ctx ~dbg ~sr ~vdi ~new_name_label = u "VDI.set_name_label"
+  let set_name_description ctx ~dbg ~sr ~vdi ~new_name_description = u "VDI.set_name_description"
   let snapshot ctx ~dbg ~sr ~vdi_info = u "VDI.snapshot"
   let clone ctx ~dbg ~sr ~vdi_info = u "VDI.clone"
   let resize ctx ~dbg ~sr ~vdi ~new_size = u "VDI.resize"


### PR DESCRIPTION
Storage backends will be expected to be able to persist these human-readable
values somewhere, so they can be retrieved over a SR.forget / SR.introduce.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>