### PR TITLE
storage: add VDI.introduce

### DIFF
--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -311,6 +311,9 @@ module VDI = struct
 	(** [stat dbg sr vdi] returns information about VDI [vdi] in SR [sr] *)
 	external stat : dbg:debug_info -> sr:sr -> vdi:vdi -> vdi_info = ""
 
+	(** [introduce dbg sr uuid sm_config location] checks that a VDI exists and returns info about it *)
+	external introduce : dbg:debug_info -> sr:sr -> uuid:string -> sm_config:(string * string) list -> location:string -> vdi_info = ""
+
 	(** [set_persistent dbg sr vdi persistent] sets [vdi]'s persistent flag to [persistent] *)
 	external set_persistent : dbg:debug_info -> sr:sr -> vdi:vdi -> persistent:bool -> unit = ""
 

--- a/storage/storage_skeleton.ml
+++ b/storage/storage_skeleton.ml
@@ -57,6 +57,7 @@ module VDI = struct
   let resize ctx ~dbg ~sr ~vdi ~new_size = u "VDI.resize"
   let destroy ctx ~dbg ~sr ~vdi = u "VDI.destroy"
   let stat ctx ~dbg ~sr ~vdi = u "VDI.stat"
+  let introduce ctx ~dbg ~sr ~uuid ~sm_config ~location = u "VDI.introduce"
   let set_persistent ctx ~dbg ~sr ~vdi ~persistent = u "VDI.set_persistent"
   let epoch_begin ctx ~dbg ~sr ~vdi = ()
   let attach ctx ~dbg ~dp ~sr ~vdi ~read_write = u "VDI.attach"


### PR DESCRIPTION
Since this is special-cased in the SMAPIv1, it needs passing through
the SMAPIv2. It won't be implemented in the SMAPIv3.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>