### PR TITLE
CP-13697: storage: add `required_cluster_stack`

### DIFF
--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -208,6 +208,7 @@ type query_result = {
 	required_api_version: string;
 	features: string list;
 	configuration: (string * string) list;
+	required_cluster_stack: string list;
 }
 
 module Query = struct


### PR DESCRIPTION
The `required_cluster_stack` allows a storage implementation to declare
that it needs a particular cluster stack (HA implementation) to run.
For example, a hypothetical OCFS2 adapter would need either O2CB or
corosync/pacemaker.

Signed-off-by: David Scott <dave.scott@citrix.com>