### PR TITLE
Use org.xen.xapi as the queue name prefix

### DIFF
--- a/example/example.ml
+++ b/example/example.ml
@@ -40,7 +40,7 @@ let comma = Re_str.regexp_string ","
 let csv = Re_str.split_delim comma
 
 let queues : string list ref = ref [
-  "org.xen.xcp.ffs";
+  "org.xen.xapi.ffs";
 ]
 
 let set_default_format _ = ()

--- a/lib/xcp_service.ml
+++ b/lib/xcp_service.ml
@@ -27,7 +27,7 @@ let log_destination = ref "syslog:daemon"
 let daemon = ref false
 let have_daemonized () = Unix.getppid () = 1
 
-let common_prefix = "org.xen.xcp."
+let common_prefix = "org.xen.xapi."
 
 let (|>) x f = f x
 


### PR DESCRIPTION
The name 'xcp' is obsolete.