### PR TITLE
CA-185923: Use a sane API for archiving/pushing SR RRDs

### DIFF
--- a/rrd/rrd_interface.ml
+++ b/rrd/rrd_interface.ml
@@ -44,12 +44,11 @@ type interdomain_info = {
 	shared_page_refs: int list;
 }
 
+exception Archive_failed of string
+
 (* The interface is defined by extern function declarations. *)
 
 external has_vm_rrd : vm_uuid:string -> bool = ""
-external sr_rrds_path : sr_uuid:string -> string = ""
-external archive_sr_rrd : sr_uuid:string -> unit = ""
-external push_sr_rrd : sr_uuid:string -> unit = ""
 
 external push_rrd : vm_uuid:string -> domid:int -> is_on_localhost:bool ->
 	unit -> unit = ""
@@ -58,6 +57,9 @@ external migrate_rrd : ?session_id:string -> remote_address:string ->
 	vm_uuid:string -> host_uuid:string -> unit -> unit = ""
 external send_host_rrd_to_master : unit -> unit = ""
 external backup_rrds : ?save_stats_locally:bool -> unit -> unit = ""
+
+external archive_sr_rrd : sr_uuid:string -> string = ""
+external push_sr_rrd : sr_uuid:string -> path:string -> unit = ""
 
 external add_host_ds : ds_name:string -> unit = ""
 external forget_host_ds : ds_name:string -> unit = ""


### PR DESCRIPTION
The interface before this patch involved asking an RRD server where for the
path that it would store the archive should it succeed, then an archive call,
and then checking that the file was there since in the error case there are no
exceptions to return.

Similarly for restoring from an archive a client would have to ask the server
where it expects these archives to be to restore, put the file there and then
call restore.

This patch simplifies the interface such that:

* The restore function takes a path to restore from in addition to the uuid;
* The archive function returns a path to the archive;
* An exception is defined so that we don't have to silently fail.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>