### PR TITLE
CA-191248: Re-add the vgpu_extra_args key

### DIFF
--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -31,6 +31,10 @@ let set_sockets_dir x =
 let default_uri () = "file:" ^ !default_path
 let json_url () = Printf.sprintf "file:%s.json" !default_path
 
+module Keys = struct
+	let vgpu_extra_args = "vgpu_extra_args"
+end
+
 type power_state =
 	| Running
 	| Halted


### PR DESCRIPTION
This was removed (along with the code that used it) as part of the GVT-g
refactoring, but it's still needed.