### PR TITLE
Accept an optional startup function in (maybe_)daemonize

### DIFF
--- a/lib/xcp_service.mli
+++ b/lib/xcp_service.mli
@@ -59,6 +59,6 @@ val serve_forever: server -> unit
 val daemon: bool ref
 val loglevel: unit -> Syslog.level
 
-val daemonize: unit -> unit
+val daemonize: ?start_fn:(unit -> unit) -> unit -> unit
 
-val maybe_daemonize: unit -> unit
+val maybe_daemonize: ?start_fn:(unit -> unit) -> unit -> unit


### PR DESCRIPTION
The startup function, if specified, is executed before the PID file is written.
If `maybe_daemonize` decides not to daemonise, it still executes the startup
function.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>