### PR TITLE
CP-18289 add nomigrate, nested_virt booleans to xenops state

### DIFF
--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -374,6 +374,8 @@ module Vm = struct
 		pv_drivers_detected: bool;
 		last_start_time: float;
 		hvm: bool;
+		nomigrate: bool; (* true: VM must not migrate *)
+		nested_virt: bool (* true: VM uses nested virtualisation *)
 	} with sexp
 
 end


### PR DESCRIPTION
The two values will be used to inform xapi about the mobility of a VM.
A VM cannot migrate if it uses nested virtualisation or is explicitly
configured to not migrate.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>