### PR TITLE
[CP-18781] Add device information in VIF.state

### DIFF
--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -501,7 +501,7 @@ module Vif = struct
 		plugged: bool;
 		kthread_pid: int;
 		media_present: bool;
-		domid: int option;
+		device: string option;
 	}
 end
 

--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -501,6 +501,7 @@ module Vif = struct
 		plugged: bool;
 		kthread_pid: int;
 		media_present: bool;
+		domid: int option;
 	}
 end
 


### PR DESCRIPTION
When updating the MTU of a VIF it can happen that the VM `domid` is still out of sync. We can use the correct `domid` value passing it via `xenopsd` as a field in `VIF.stat`.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>