### PR TITLE
[WIP] Use List.exists instead of List.fold_left

### DIFF
--- a/storage/vdi_automaton.ml
+++ b/storage/vdi_automaton.ml
@@ -87,13 +87,11 @@ let ( + ) state operation =
 		| Activated _, Detach     -> error ()
 
 let superstate states =
-	let activated = List.fold_left (fun acc s ->
-		acc || (s = Activated RO) || (s = Activated RW)) false states in
-	let rw = List.fold_left (fun acc s ->
-		acc || (s = Activated RW) || (s = Attached RW)) false states in
 	if states = []
 	then Detached
 	else
+    let activated = List.exists (function Activated _ -> true | _ -> false) states in
+    let rw = List.exists (function Activated RW | Attached RW -> true | _ -> false) states in
 		if activated
 		then Activated (if rw then RW else RO)
 		else Attached (if rw then RW else RO)


### PR DESCRIPTION
These folds can be simplified, they are equivalent to List.exists.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>