### PR TITLE
Fix OCaml compiler warnings

### DIFF
--- a/example/example.ml
+++ b/example/example.ml
@@ -68,4 +68,3 @@ let _ =
   | `Error m ->
     Printf.fprintf stderr "Error: %s\n%!" m;
     exit 1
-  ()

--- a/lib/cohttp_posix_io.ml
+++ b/lib/cohttp_posix_io.ml
@@ -105,7 +105,7 @@ module Unbuffered_IO = struct
     remaining = 0 || (n > 0 && (read_into_exactly ic buf (ofs + n) (len - n)))
 
   let read_exactly ic len =
-    let buf = String.create len in
+    let buf = Bytes.create len in
     read_into_exactly ic buf 0 len >>= function
     | true -> return (Some buf)
     | false -> return None
@@ -147,7 +147,7 @@ module Buffered_IO = struct
   let read_into_exactly ic buf ofs len = try really_input ic buf ofs len; true with _ -> false
 
   let read_exactly ic len =
-    let buf = String.create len in
+    let buf = Bytes.create len in
     read_into_exactly ic buf 0 len >>= function
     | true -> return (Some buf)
     | false -> return None

--- a/lib/posix_channel.ml
+++ b/lib/posix_channel.ml
@@ -16,7 +16,7 @@ module CBuf = struct
   }
 
   let empty length = {
-    buffer = String.create length;
+    buffer = Bytes.create length;
     len = 0;
     start = 0;
     r_closed = false;

--- a/lib/syslog.ml
+++ b/lib/syslog.ml
@@ -54,7 +54,6 @@ let level_of_string s =
 	| "emergency"        -> Emerg
 	| "alert"            -> Alert
 	| "critical"         -> Crit
-	| "debug"            -> Debug; 
 	| "error" | "err"    -> Err
 	| "warning" | "warn" -> Warning
 	| "notice"           -> Notice

--- a/lib_test/debug_test.ml
+++ b/lib_test/debug_test.ml
@@ -64,8 +64,8 @@ let test_debug_set_level () =
 
 
 let test_debug_set_level_multiple_loggers () = 
-        let a = (module Debug.Make(struct let name = "aaaa" end) : Debug.DEBUG) in
-        let b = (module Debug.Make(struct let name = "bbbb" end) : Debug.DEBUG) in
+        let _ = (module Debug.Make(struct let name = "aaaa" end) : Debug.DEBUG) in
+        let _ = (module Debug.Make(struct let name = "bbbb" end) : Debug.DEBUG) in
         Debug.reset_levels ();
 
         assert_levels "aaaa"    (false, false, false, false);

--- a/network/network_stats.ml
+++ b/network/network_stats.ml
@@ -88,7 +88,7 @@ module File_helpers = struct
 	(** [fd_blocks_fold block_size f start fd] folds [f] over blocks (strings)
 	    from the fd [fd] with initial value [start] *)
 	let fd_blocks_fold block_size f start fd = 
-		let block = String.create block_size in
+		let block = Bytes.create block_size in
 		let rec fold acc = 
 			let n = Unix.read fd block 0 block_size in
 			(* Consider making the interface explicitly use Substrings *)


### PR DESCRIPTION
Fix the warnings emitted by version 4.02.2 of the OCaml compiler. (I used the [xs-shipyard docker image](https://github.com/lindig/xs-shipyard) for compilation.)

I should probably squash the commits in case they are merged, but multiple smaller commits might be easier to review in the meantime.