### PR TITLE
CP-20431: MxGPU in Xenops_interface.Vgpu

### DIFF
--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -120,6 +120,7 @@ module Vgpu = struct
 	type implementation =
 		| GVT_g of gvt_g
 		| Nvidia of nvidia
+		| MxGPU of mxgpu
 
 	type id = string * string
 

--- a/xen/xenops_types.ml
+++ b/xen/xenops_types.ml
@@ -39,6 +39,11 @@ module Vgpu = struct
     config_file: string;
   } with sexp, rpc
 
+  type mxgpu = {
+    sched: int;
+    framebufferbytes: int64;
+  } with sexp, rpc
+
 end
 
 module Vm = struct


### PR DESCRIPTION
Broaden the Vgpu.implementation type to include MxGPU implementations.
The mxgpu type contains the configuration values to be passed to qemu.