### PR TITLE
gpumon_interface: extract Nvidia exception

### DIFF
--- a/gpumon/gpumon_interface.ml
+++ b/gpumon/gpumon_interface.ml
@@ -25,7 +25,9 @@ type compatibility = Compatible | Incompatible of incompatibility_reason list
 type pgpu_address = string
 type nvidia_pgpu_metadata = string
 
+(** Exception raised when gpumon is unable to load the nvml nvidia library *)
 exception NvmlInterfaceNotAvailable
+(** Exception raised by the c bindings to the nvml nvidia library*)
 exception NvmlFailure of string
 
 

--- a/gpumon/gpumon_interface.ml
+++ b/gpumon/gpumon_interface.ml
@@ -25,11 +25,12 @@ type compatibility = Compatible | Incompatible of incompatibility_reason list
 type pgpu_address = string
 type nvidia_pgpu_metadata = string
 
+exception NvmlInterfaceNotAvailable
+exception NvmlFailure of string
+
+
 module Nvidia = struct
   (** Compatibility checking interface for Nvidia vGPUs *)
-
-  exception InterfaceNotAvailable
-  exception Failure of string
 
   (** Get the metadata for a pGPU, given its address (PCI bus ID). *)
   external get_pgpu_metadata: debug_info -> pgpu_address -> nvidia_pgpu_metadata = ""


### PR DESCRIPTION
Unfortunately the exception inside a sub-module is not usable in `try..with` statements.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>