### PR TITLE
[CP-22597] Add other_config to vgpu records for temporary migration vgpu_map

### DIFF
--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -130,6 +130,7 @@ module Vgpu = struct
 		position: int;
 		physical_pci_address: Pci.address;
 		implementation: implementation;
+		other_config: (string*string) list;
 	}
 
 	let default_t = {
@@ -137,6 +138,7 @@ module Vgpu = struct
 		position = 0;
 		physical_pci_address = Pci.{domain = 0; bus = 0; dev = 0; fn = 0};
 		implementation = Empty;
+		other_config = [];
 	}
 
 	let upgrade_pci_info x =


### PR DESCRIPTION
This goes hand in hand with https://github.com/xapi-project/xen-api/pull/3073