### PR TITLE
Revert "[CP-22597] Add other_config to vgpu records"

### DIFF
--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -130,7 +130,6 @@ module Vgpu = struct
 		position: int;
 		physical_pci_address: Pci.address;
 		implementation: implementation;
-		other_config: (string*string) list;
 	}
 
 	let default_t = {
@@ -138,7 +137,6 @@ module Vgpu = struct
 		position = 0;
 		physical_pci_address = Pci.{domain = 0; bus = 0; dev = 0; fn = 0};
 		implementation = Empty;
-		other_config = [];
 	}
 
 	let upgrade_pci_info x =


### PR DESCRIPTION
This ended up here as an oversight. The `other-config` map used for the
vgpu migration is in fact the one in xapi database and does not require
further changes to the idl or to xenopsd.

This reverts commit 5dedafa107f7a9117ba7f9aa60c53add94200721.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>