### PR TITLE
CP-22500: add xenops interface support for template data

### DIFF
--- a/xen/xenops_types.ml
+++ b/xen/xenops_types.ml
@@ -186,6 +186,7 @@ module Vm = struct
     ssidref: int32;
     xsdata: (string * string) list;
     platformdata: (string * string) list;
+    templatedata: (string * string) list;
     bios_strings: (string * string) list;
     ty: builder_info;
     suppress_spurious_page_faults: bool;
@@ -210,6 +211,7 @@ module Vm = struct
     ssidref = 0l;
     xsdata = [];
     platformdata = [];
+    templatedata = [];
     bios_strings = [];
     ty = default_builder_info;
     suppress_spurious_page_faults = false;


### PR DESCRIPTION
This patch is necessary to support the following PRs:
- xapi: PR 3133
- xenopsd: PR 356
- xenops-cli: PR 20

I was able to rebuild the iso by having this PR and all the PRs above present.