### PR TITLE
Rename VDI.export_changed_blocks to VDI.list_changed_blocks

### DIFF
--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -413,8 +413,8 @@ module VDI = struct
   (** [data_destroy dbg sr vdi] deletes the data of the snapshot [vdi] without deleting its changed block tracking metadata *)
   external data_destroy: dbg:debug_info -> sr:sr -> vdi:vdi -> unit = ""
 
-  (** [export_changed_blocks dbg sr vdi_from vdi_to] returns the blocks that have changed between [vdi_from] and [vdi_to] as a base64-encoded bitmap string *)
-  external export_changed_blocks: dbg:debug_info -> sr:sr -> vdi_from:vdi -> vdi_to:vdi -> string = ""
+  (** [list_changed_blocks dbg sr vdi_from vdi_to] returns the blocks that have changed between [vdi_from] and [vdi_to] as a base64-encoded bitmap string *)
+  external list_changed_blocks: dbg:debug_info -> sr:sr -> vdi_from:vdi -> vdi_to:vdi -> string = ""
 
 end
 

--- a/storage/storage_skeleton.ml
+++ b/storage/storage_skeleton.ml
@@ -79,7 +79,7 @@ module VDI = struct
   let enable_cbt ctx ~dbg ~sr ~vdi = u "VDI.enable_cbt"
   let disable_cbt ctx ~dbg ~sr ~vdi = u "VDI.disable_cbt"
   let data_destroy ctx ~dbg ~sr ~vdi = u "VDI.data_destroy"
-  let export_changed_blocks ctx ~dbg ~sr ~vdi_from ~vdi_to = u "VDI.export_changed_blocks"
+  let list_changed_blocks ctx ~dbg ~sr ~vdi_from ~vdi_to = u "VDI.list_changed_blocks"
 end
 
 let get_by_name ctx ~dbg ~name = u "get_by_name"


### PR DESCRIPTION
Because the latter is clearer. People found the function name
export_changed_blocks confusing, because it suggested that the actual
data of the changed blocks will be "exported".

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>