### PR TITLE
CP-22446: Add cbt_enabled parameter to vdi_info

### DIFF
--- a/storage/storage_client.ml
+++ b/storage/storage_client.ml
@@ -53,6 +53,7 @@ let default_vdi_info = {
   snapshot_time = "19700101T00:00:00Z";
   snapshot_of = "";
   read_only = false;
+  cbt_enabled = false;
   virtual_size = 0L;
   physical_utilisation = 0L;
   persistent = true;

--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -64,6 +64,7 @@ type vdi_info = {
     snapshot_of: vdi;
     (* managed: workaround via XenAPI *)
     read_only: bool;
+    cbt_enabled: bool;
     (* missing: workaround via XenAPI *)
     virtual_size: int64;
     physical_utilisation: int64;
@@ -84,6 +85,7 @@ let default_vdi_info = {
     snapshot_time = Stdext.Date.to_string Stdext.Date.never;
     snapshot_of = "";
     read_only = false;
+    cbt_enabled = false;
     virtual_size = 0L;
     physical_utilisation = 0L;
     persistent = true;


### PR DESCRIPTION
To enable SR scan to correctly set this parameter in case the VDI isn't
yet in xapi's database, instead of defaulting to false. This change only
affect's xapi, because SMAPIv2 is an internal storage interface that
only exists in xapi.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>