### PR TITLE
CP-22945: runtime coverage dumping support for Xcp_service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,6 @@ gh-pages:
 
 reindent:
 	    git ls-files '*.ml' '*.mli' | xargs ocp-indent --syntax cstruct -i
+
+runtime-coverage:
+	    BISECT_RUNTIME=YES make

--- a/lib/coverage/disabled.ml
+++ b/lib/coverage/disabled.ml
@@ -1,0 +1,2 @@
+let init _ = ()
+let dispatcher_init _ = ()

--- a/lib/coverage/enabled.ml
+++ b/lib/coverage/enabled.ml
@@ -1,0 +1,117 @@
+(** This module sets up the env variable for bisect_ppx which describes
+ *  where log files are written.
+ *)
+
+module D=Debug.Make(struct let name="coverage" end)
+let prefix = "org.xen.xapi.coverage"
+
+module Bisect = struct
+  let dump jobid =
+    let bisect_prefix = Unix.getenv "BISECT_FILE" in
+    (* dump coverage information in same location as it would normally
+       get dumped on exit, except also embed the jobid to make it easier to group.
+       Relies on [open_temp_file] generating a unique filename given a prefix/suffix to
+       avoid clashes with filenames created atexit by bisect itself. *)
+    let tmp, ch = Filename.open_temp_file
+                    ~temp_dir:(Filename.dirname bisect_prefix)
+                    (Filename.basename bisect_prefix)
+                    (Printf.sprintf ".%Ld.out" jobid) in
+    try
+      Bisect.Runtime.dump_counters_exn ch;
+      D.debug "Saved coverage data to %s" tmp;
+      close_out_noerr ch;
+      (* Keep file - will be collected by XenRT *)
+      tmp
+    with e ->
+      Sys.remove tmp;
+      D.warn "Failed to save coverage: %s" (Printexc.to_string e);
+      raise e
+
+  let reset () =
+    Bisect.Runtime.reset_counters ();
+    D.debug "Coverage counters reset";
+    "" (* no file produced *)
+
+  let init_env name =
+    let (//)    = Filename.concat in
+    let tmpdir  = Filename.get_temp_dir_name () in
+    try 
+      ignore (Sys.getenv "BISECT_FILE") 
+    with Not_found ->
+      Unix.putenv "BISECT_FILE" (tmpdir // Printf.sprintf "bisect-%s-" name)
+
+  let process body =
+    match Stringext.split ~on:' ' body with
+    | ["reset"] -> reset ()
+    | ["dump"; jobid] -> jobid |> Int64.of_string |> dump
+    | _ -> failwith body
+
+  let init name =
+    init_env name;
+    let queue_name = prefix ^ "." ^ name in
+    let (_:Thread.t) =
+      Thread.create (Protocol_unix.Server.listen ~process
+                       ~switch:!Xcp_client.switch_path ~queue:queue_name) () in
+    D.debug "Started coverage API thread on %s" queue_name;
+    ()
+end
+
+module Dispatcher = struct
+  let self = prefix ^ ".dispatch"
+  open Protocol_unix
+
+  let rpc_ignore_err ~t ~body queue =
+    D.debug "Dispatching %s to %s" body queue;
+    match Client.(rpc ~t ~queue ~body () |> error_to_msg) with
+    | `Ok x -> x
+    | `Error (`Msg e) ->
+       D.info "Failed to get coverage data from %s: %s" queue e;
+       ""
+
+  let string_of_result = function
+    | `Ok s -> s
+    | `Error (`Msg e) ->
+       D.info "Failed to get coverage data: %s" e;
+       "ERROR"
+
+  let process = fun body ->
+    let open Message_switch.Mresult in
+    D.debug "Coverage dispatcher received %s" body;
+    let result = begin
+        Client.connect ~switch:!Xcp_client.switch_path () >>= fun t ->
+        Client.list ~t ~prefix ~filter:`Alive () >>= fun queues ->
+        queues |>
+          (* filter out ourselves *)
+          List.filter (fun q -> self <> q) |>
+
+          (* best-effort: collect and return all non-failed results, log errors *)
+          List.rev_map (rpc_ignore_err ~t ~body) |>
+
+          (* multiple return values converted to a single string, suitable for use in a command like:
+          mv $(message-cli call org.xen.xapi.coverage.dispatch --timeout 60 --body 'dump {jobid}') /tmp/coverage/
+           *)
+          String.concat " " |>
+          ok
+      end |> Client.error_to_msg |> string_of_result in
+    D.debug "Coverage dispatcher replying to '%s': %s" body result;
+    result
+
+  let init () =
+    (* receives command and dispatches to all other coverage message queues *)
+    let (_:Thread.t) =
+      Thread.create (Protocol_unix.Server.listen ~process
+                       ~switch:!Xcp_client.switch_path ~queue:self) () in
+    D.debug "Started coverage API dispatcher on %s" self;
+    ()
+end
+
+(** [init name] sets up coverage profiling for binary [name]. You could 
+ *  use [Sys.argv.(0)] for [name].
+ *)
+let init name =
+  D.info "Coverage runtime initialized";
+  Bisect.init name
+
+let dispatcher_init name =
+  init name;
+  Dispatcher.init ()

--- a/lib/coverage/enabled.ml
+++ b/lib/coverage/enabled.ml
@@ -109,8 +109,9 @@ end
  *  use [Sys.argv.(0)] for [name].
  *)
 let init name =
-  D.info "Coverage runtime initialized";
-  Bisect.init name
+  D.info "About to initialize coverage runtime";
+  Bisect.init name;
+  D.info "Coverage runtime initialized"
 
 let dispatcher_init name =
   init name;

--- a/lib/coverage/enabled.ml
+++ b/lib/coverage/enabled.ml
@@ -29,8 +29,7 @@ module Bisect = struct
 
   let reset () =
     Bisect.Runtime.reset_counters ();
-    D.debug "Coverage counters reset";
-    "" (* no file produced *)
+    D.debug "Coverage counters reset"
 
   let init_env name =
     let (//)    = Filename.concat in
@@ -42,7 +41,7 @@ module Bisect = struct
 
   let process body =
     match Stringext.split ~on:' ' body with
-    | ["reset"] -> reset ()
+    | ["reset"] -> reset (); ""
     | ["dump"; jobid] -> jobid |> Int64.of_string |> dump
     | _ -> failwith body
 

--- a/lib/coverage/enabled.ml
+++ b/lib/coverage/enabled.ml
@@ -114,5 +114,4 @@ let init name =
   D.info "Coverage runtime initialized"
 
 let dispatcher_init name =
-  init name;
   Dispatcher.init ()

--- a/lib/coverage/enabled.ml
+++ b/lib/coverage/enabled.ml
@@ -11,7 +11,7 @@ module Bisect = struct
     (* dump coverage information in same location as it would normally
        get dumped on exit, except also embed the jobid to make it easier to group.
        Relies on [open_temp_file] generating a unique filename given a prefix/suffix to
-       avoid clashes with filenames created atexit by bisect itself. *)
+       avoid clashes with filenames created at exit by bisect itself. *)
     let tmp, ch = Filename.open_temp_file
                     ~temp_dir:(Filename.dirname bisect_prefix)
                     (Filename.basename bisect_prefix)

--- a/lib/coverage/enabled.ml
+++ b/lib/coverage/enabled.ml
@@ -6,8 +6,9 @@ module D=Debug.Make(struct let name="coverage" end)
 let prefix = "org.xen.xapi.coverage"
 
 module Bisect = struct
+  let bisect_file = "BISECT_FILE"
   let dump jobid =
-    let bisect_prefix = Unix.getenv "BISECT_FILE" in
+    let bisect_prefix = Unix.getenv bisect_file in
     (* dump coverage information in same location as it would normally
        get dumped on exit, except also embed the jobid to make it easier to group.
        Relies on [open_temp_file] generating a unique filename given a prefix/suffix to
@@ -34,10 +35,10 @@ module Bisect = struct
   let init_env name =
     let (//)    = Filename.concat in
     let tmpdir  = Filename.get_temp_dir_name () in
-    try 
-      ignore (Sys.getenv "BISECT_FILE") 
+    try
+      ignore (Sys.getenv bisect_file)
     with Not_found ->
-      Unix.putenv "BISECT_FILE" (tmpdir // Printf.sprintf "bisect-%s-" name)
+      Unix.putenv bisect_file (tmpdir // Printf.sprintf "bisect-%s-" name)
 
   let process body =
     match Stringext.split ~on:' ' body with

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -22,11 +22,25 @@ let coverage_rewriter =
   else
     ""
 
+let runtime_coverage_enabled, coverage_dep =
+  let use_bisect_runtime = match Unix.getenv "BISECT_RUNTIME" with
+    | "YES" -> true
+    | _ -> false
+    | exception Not_found -> false in
+  if use_bisect_runtime then
+    "enabled.ml", "bisect_ppx.runtime"
+  else
+    "disabled.ml", ""
+
 let rewriters = ["ppx_deriving_rpc"]
 let flags = flags rewriters
 
 let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (jbuild_version 1)
+
+(rule
+  ((targets (xcp_coverage.ml))
+   (action (copy coverage/%s ${@}))))
 
 (library
  ((name xcp)
@@ -35,7 +49,8 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (modules (:standard \ channel_helper scheduler task_server updates))
   (c_names (syslog_stubs))
   (libraries
-   (cmdliner
+   (%s
+    cmdliner
     cohttp
     fd-send-recv
     message_switch.unix
@@ -80,4 +95,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (alias
  ((name runtest)
   (deps (channel_helper.exe))))
-|} flags coverage_rewriter flags coverage_rewriter flags
+|} runtime_coverage_enabled flags coverage_dep coverage_rewriter flags coverage_rewriter flags

--- a/lib/xcp_coverage.mli
+++ b/lib/xcp_coverage.mli
@@ -1,0 +1,13 @@
+(* the build system chooses either 'coverage/enabled.ml' or
+ * 'coverage/disabled.ml' as an implementation *)
+
+(** [init name] sets up coverage profiling for binary [name]. You could
+ *  use [Sys.argv.(0)] for [name].
+ *)
+
+val init: string -> unit
+
+(** [dispatcher_init name] is like [init name] except it also initializes
+ * the toplevel coverage API dispatcher on a system.
+ * This is meant to be called only by XAPI *)
+val dispatcher_init : string -> unit

--- a/lib/xcp_coverage.mli
+++ b/lib/xcp_coverage.mli
@@ -10,7 +10,8 @@
 
 val init: string -> unit
 
-(** [dispatcher_init name] is like [init name] except it also initializes
- * the toplevel coverage API dispatcher on a system.
- * This is meant to be called only by XAPI *)
+(** [dispatcher_init name] only initializes the toplevel coverage API dispatcher on a system.
+ * This is meant to be called only by XAPI, which will have to call both [init]
+ * and [dispatcher_init].
+ *)
 val dispatcher_init : string -> unit

--- a/lib/xcp_coverage.mli
+++ b/lib/xcp_coverage.mli
@@ -1,5 +1,8 @@
-(* the build system chooses either 'coverage/enabled.ml' or
- * 'coverage/disabled.ml' as an implementation *)
+(* The build system chooses either 'coverage/enabled.ml' or
+ * 'coverage/disabled.ml' as an implementation.
+ * Executables need to make exactly one call to exactly one of
+ * [init], [dispatcher_init] or [Xcp_service.configure2].
+ * *)
 
 (** [init name] sets up coverage profiling for binary [name]. You could
  *  use [Sys.argv.(0)] for [name].

--- a/lib/xcp_service.ml
+++ b/lib/xcp_service.ml
@@ -360,6 +360,7 @@ type ('a, 'b) error = [
 
 let configure2 ~name ~version ~doc ?(options=[]) ?(resources=[]) () =
   try
+    Xcp_coverage.init name;
     configure_common ~options ~resources
       (fun config_spec ->
         match Term.eval (command_of ~name ~version ~doc config_spec) with


### PR DESCRIPTION
Long running daemons like xapi, xenopsd, etc. can benefit from dumping coverage
data at runtime, not only at exit.

Instead of duplicating the code in each daemon provide library code, that:
 * logs a message on startup so we know it is active
 * set BISECT_FILE env var to dump coverage in the appropriate place
 (the default of dumping in the current directory is not good for a daemon)
 * listen on `org.xen.xapi.coverage.<name>` message queue for
 runtime coverage dump commands
 * all daemons that use `Xcp_service.configure2` will get this automatically

This code is a no-op by default, only enabled when `make runtime-coverage` is used,
i.e. normally nothing listens on the "org.xen.xapi.coverage" message queue.

It also provides a coverage dispatcher listening on "org.xen.xapi.coverage.dispatch"
that will list all "org.xen.xapi.coverage" message queues and send the coverage
dump command to them.
This is meant to be called once, systemd wide, by XAPI to provide a single
entrypoint for dumping all coverage: `Xcp_coverage.dispatcher_init ()`.

I have tested a version of this code a while ago, test on latest master pending, just thought to open the PR early  for feedback on the general approach.

I should probably submit an update to the design as well, as it still references OASIS:
https://xapi-project.github.io/profiling/coverage.html