### PR TITLE
CP-24185 add gpumon_if.get_pgpu_vgpu_compatibility

### DIFF
--- a/gpumon/gpumon_interface.ml
+++ b/gpumon/gpumon_interface.ml
@@ -45,6 +45,17 @@ module Nvidia = struct
     * pgpu_metadata = metadata of the pGPU to check compatibility for. *)
   external get_pgpu_vm_compatibility: debug_info -> pgpu_address -> domid -> nvidia_pgpu_metadata -> compatibility = ""
 
+  (** Obtain meta data for all vGPUs running in a domain. The
+   * [pgpu_address] is a PCI identifier of the form
+   * domain:bus:device.function
+   *)
+  external get_vgpu_metadata
+    : debug_info
+    -> domid
+    -> pgpu_address
+    -> nvidia_vgpu_metadata list
+    = ""
+
   (** Check compatibility between a pGPU (on a host) and a list of vGPUs
    * (assigned to a VM). The use case is VM.suspend/VM.resume: before
    * VM.resume [nvidia_vgpu_metadata] of the suspended VM is checked

--- a/gpumon/gpumon_interface.ml
+++ b/gpumon/gpumon_interface.ml
@@ -24,6 +24,7 @@ type compatibility = Compatible | Incompatible of incompatibility_reason list
 
 type pgpu_address = string
 type nvidia_pgpu_metadata = string
+type nvidia_vgpu_metadata = string
 
 (** Exception raised when gpumon is unable to load the nvml nvidia library *)
 exception NvmlInterfaceNotAvailable
@@ -43,4 +44,11 @@ module Nvidia = struct
     * domid = domain ID of the VM in which the vGPU(s) is running.
     * pgpu_metadata = metadata of the pGPU to check compatibility for. *)
   external get_pgpu_vm_compatibility: debug_info -> pgpu_address -> domid -> nvidia_pgpu_metadata -> compatibility = ""
+
+  external get_pgpu_vgpu_compatibility
+    : debug_info
+    -> nvidia_pgpu_metadata
+    -> nvidia_vgpu_metadata list
+    -> compatibility
+    = ""
 end

--- a/gpumon/gpumon_interface.ml
+++ b/gpumon/gpumon_interface.ml
@@ -45,6 +45,12 @@ module Nvidia = struct
     * pgpu_metadata = metadata of the pGPU to check compatibility for. *)
   external get_pgpu_vm_compatibility: debug_info -> pgpu_address -> domid -> nvidia_pgpu_metadata -> compatibility = ""
 
+  (** Check compatibility between a pGPU (on a host) and a list of vGPUs
+   * (assigned to a VM). The use case is VM.suspend/VM.resume: before
+   * VM.resume [nvidia_vgpu_metadata] of the suspended VM is checked
+   * against the [nvidia_pgpu_metadata] on the host where the VM is
+   * resumed. A VM may use several vGPUs.
+   *)
   external get_pgpu_vgpu_compatibility
     : debug_info
     -> nvidia_pgpu_metadata


### PR DESCRIPTION
This exposes a new function implemented in gpumon for checking the
compatibility of vGPU and pGPU. This  PR should be merged before 
https://github.com/xenserver/gpumon/pull/25 is merged.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>