### PR TITLE
CP-26471: Renamed library after porting it to jbuilder.

### DIFF
--- a/lib/coverage/enabled.ml
+++ b/lib/coverage/enabled.ml
@@ -50,7 +50,7 @@ module Bisect = struct
     init_env name;
     let queue_name = prefix ^ "." ^ name in
     let (_:Thread.t) =
-      Thread.create (Protocol_unix.Server.listen ~process
+      Thread.create (Message_switch_unix.Protocol_unix.Server.listen ~process
                        ~switch:!Xcp_client.switch_path ~queue:queue_name) () in
     D.debug "Started coverage API thread on %s" queue_name;
     ()
@@ -58,7 +58,7 @@ end
 
 module Dispatcher = struct
   let self = prefix ^ ".dispatch"
-  open Protocol_unix
+  open Message_switch_unix.Protocol_unix
 
   let rpc_ignore_err ~t ~body queue =
     D.debug "Dispatching %s to %s" body queue;
@@ -75,7 +75,7 @@ module Dispatcher = struct
        "ERROR"
 
   let process = fun body ->
-    let open Message_switch.Mresult in
+    let open Message_switch_core.Mresult in
     D.debug "Coverage dispatcher received %s" body;
     let result = begin
         Client.connect ~switch:!Xcp_client.switch_path () >>= fun t ->
@@ -99,13 +99,13 @@ module Dispatcher = struct
   let init () =
     (* receives command and dispatches to all other coverage message queues *)
     let (_:Thread.t) =
-      Thread.create (Protocol_unix.Server.listen ~process
+      Thread.create (Message_switch_unix.Protocol_unix.Server.listen ~process
                        ~switch:!Xcp_client.switch_path ~queue:self) () in
     D.debug "Started coverage API dispatcher on %s" self;
     ()
 end
 
-(** [init name] sets up coverage profiling for binary [name]. You could 
+(** [init name] sets up coverage profiling for binary [name]. You could
  *  use [Sys.argv.(0)] for [name].
  *)
 let init name =

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -53,7 +53,8 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     cmdliner
     cohttp
     fd-send-recv
-    message_switch.unix
+    message-switch-core
+    message-switch-unix
     ppx_deriving_rpc
     re
     rpclib

--- a/lib/xcp_client.ml
+++ b/lib/xcp_client.ml
@@ -16,28 +16,28 @@
 
 module Request = Cohttp.Request.Make(Cohttp_posix_io.Buffered_IO)
 module Response = Cohttp.Response.Make(Cohttp_posix_io.Buffered_IO)
-    
+
 let get_user_agent () = Sys.argv.(0)
 
 let switch_path = ref "/var/run/message-switch/sock"
-let use_switch = ref true 
+let use_switch = ref true
 
 let get_ok = function
   | `Ok x -> x
   | `Error e ->
       let b = Buffer.create 16 in
       let fmt = Format.formatter_of_buffer b in
-      Protocol_unix.Client.pp_error fmt e;
+      Message_switch_unix.Protocol_unix.Client.pp_error fmt e;
       Format.pp_print_flush fmt ();
       failwith (Buffer.contents b)
 
 let switch_rpc queue_name string_of_call response_of_string =
-	let t = get_ok (Protocol_unix.Client.connect ~switch:!switch_path ()) in
+	let t = get_ok (Message_switch_unix.Protocol_unix.Client.connect ~switch:!switch_path ()) in
 	fun call ->
-		response_of_string (get_ok (Protocol_unix.Client.rpc ~t ~queue:queue_name ~body:(string_of_call call) ()))
+		response_of_string (get_ok (Message_switch_unix.Protocol_unix.Client.rpc ~t ~queue:queue_name ~body:(string_of_call call) ()))
 
 let split_colon str =
-  try 
+  try
     let x = String.index str ':' in
     let uname = String.sub str 0 x in
     let passwd = String.sub str (x+1) (String.length str - x - 1) in
@@ -65,7 +65,7 @@ let http_rpc string_of_call response_of_string ?(srcstr="unset") ?(dststr="unset
 			| _ -> headers
 			end
 		| None -> headers in
-	
+
 
 	let http_req = Cohttp.Request.make ~meth:`POST ~version:`HTTP_1_1 ~headers uri in
 

--- a/lib/xcp_service.ml
+++ b/lib/xcp_service.ml
@@ -162,14 +162,14 @@ let common_options = [
 				error "Processing disabled-logging-for = %s: %s" x (Printexc.to_string e)
 		), (fun () -> String.concat " " (setify (List.map fst (Debug.disabled_modules ())))), "A space-separated list of debug modules to suppress logging from";
 
-	"loglevel", Arg.String 
+	"loglevel", Arg.String
 		(fun x ->
 			debug "Parsing [%s]" x;
 			try
 				log_level := Syslog.level_of_string x;
 				Debug.set_level !log_level
 			with e ->
-				error "Processing loglevel = %s: %s" x (Printexc.to_string e)), 
+				error "Processing loglevel = %s: %s" x (Printexc.to_string e)),
 		(fun () -> Syslog.string_of_level !log_level), "Log level";
 
 	"inventory", Arg.Set_string Inventory.inventory_filename, (fun () -> !Inventory.inventory_filename), "Location of the inventory file";
@@ -482,7 +482,7 @@ let serve_forever = function
 		done
 	| Queue(queue_name, fn) ->
 		let process x = Jsonrpc.string_of_response (fn (Jsonrpc.call_of_string x)) in
-		let _ = Protocol_unix.Server.listen ~process ~switch:!Xcp_client.switch_path ~queue:queue_name () in
+		let _ = Message_switch_unix.Protocol_unix.Server.listen ~process ~switch:!Xcp_client.switch_path ~queue:queue_name () in
 		let rec forever () =
 			Thread.delay 3600.;
 			forever () in

--- a/xcp.opam
+++ b/xcp.opam
@@ -15,7 +15,8 @@ depends: [
   "fd-send-recv"
   "jbuilder" {build & >= "1.0+beta11"}
   "lwt" {< "3.0.0" & >= "2.7.1"}
-  "message-switch"
+  "message-switch-core"
+  "message-switch-unix"
   "ocamlfind" {build}
   "ounit" {>= "2.0.0"}
   "ppx_sexp_conv"


### PR DESCRIPTION
This depends on xapi-project/message-switch#37; please do not merge before xs-opam is updated.