### PR TITLE
CP-22945: coverage: fix compiler warning on unused variable

### DIFF
--- a/lib/coverage/enabled.ml
+++ b/lib/coverage/enabled.ml
@@ -113,5 +113,5 @@ let init name =
   Bisect.init name;
   D.info "Coverage runtime initialized"
 
-let dispatcher_init name =
+let dispatcher_init _name =
   Dispatcher.init ()


### PR DESCRIPTION
Trying to use `make runtime-coverage` from the spec instead of calling jbuilder directly, and it was failing on this line due to `jbuilder build --dev`.
With this warning fixed `make runtime-coverage` works.