### PR TITLE
Makefile: do not use --dev in the release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,12 @@ OPAM_LIBDIR=$(DESTDIR)$(shell opam config var lib)
 
 .PHONY: build release install uninstall clean test doc reindent
 
+release:
+	    jbuilder build @install -j $$(getconf _NPROCESSORS_ONLN)
+
 build:
 	    jbuilder build @install --dev -j $$(getconf _NPROCESSORS_ONLN)
 
-release:
-	    jbuilder build @install
 
 install:
 	    jbuilder install --prefix=$(OPAM_PREFIX) --libdir=$(OPAM_LIBDIR)

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,5 @@ reindent:
 
 runtime-coverage:
 	    BISECT_RUNTIME=YES make
+
+.DEFAULT_GOAL := release


### PR DESCRIPTION
The `--dev` flag injects `ocamlc` flags that are not under our control. If we want to make the build fail on warning we should do it by adding `-warn-error -a` or whatever appropriate in the `jbuild` files instead.

We should still retain the `build` target, to be used when developing to fix unnecessary warnings.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>