### PR TITLE
Build CLI tools with runtest

### DIFF
--- a/cluster/jbuild
+++ b/cluster/jbuild
@@ -46,4 +46,9 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     rpclib.markdown
     xcp.cluster))))
 
+(alias
+ ((name runtest)
+  (deps (cluster_cli.exe))
+  (action (run ${<}))))
+
 |} (flags rewriters_ppx) coverage_rewriter

--- a/cluster/jbuild
+++ b/cluster/jbuild
@@ -46,9 +46,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     rpclib.markdown
     xcp.cluster))))
 
-(alias
- ((name runtest)
-  (deps (cluster_cli.exe))
-  (action (run ${<}))))
-
 |} (flags rewriters_ppx) coverage_rewriter

--- a/cluster/jbuild
+++ b/cluster/jbuild
@@ -16,7 +16,6 @@ let flags = function
   go ic ""
 
 let rewriters_ppx = ["ppx_deriving_rpc"; "ppx_sexp_conv"]
-let rewriters_camlp4 = ["rpclib.idl -syntax camlp4o"]
 
 let coverage_rewriter = ""
 (* (preprocess (pps)) doesn't work with camlp4 and  the other ppx derivers,

--- a/cluster/jbuild
+++ b/cluster/jbuild
@@ -15,7 +15,7 @@ let flags = function
   in
   go ic ""
 
-let rewriters_ppx = ["ppx_deriving_rpc"; "ppx_sexp_conv"]
+let rewriters_ppx = ["ppx_deriving_rpc"]
 
 let coverage_rewriter = ""
 (* (preprocess (pps)) doesn't work with camlp4 and  the other ppx derivers,

--- a/memory/jbuild
+++ b/memory/jbuild
@@ -48,4 +48,10 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     rpclib.cmdliner
     rpclib.markdown
     xcp.memory))))
+
+(alias
+ ((name runtest)
+  (deps (memory_cli.exe))
+  (action (run ${<}))))
+
 |} flags coverage_rewriter

--- a/v6/jbuild
+++ b/v6/jbuild
@@ -49,4 +49,9 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     rpclib.markdown
     xcp.v6))))
 
+(alias
+ ((name runtest)
+  (deps (v6_cli.exe))
+  (action (run ${<}))))
+
 |} flags coverage_rewriter


### PR DESCRIPTION
This PR builds all daemon debugger CLI tools with `jbuilder runtest`/`make test`.
It also removes unnecessary PPX rewriter dependencies from `cluster/jbuild`

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>