### PR TITLE
[477 idl part2] SR.create API change and sharable flag

### DIFF
--- a/storage/storage_client.ml
+++ b/storage/storage_client.ml
@@ -41,21 +41,4 @@ module Client = Storage_interface.Client(struct
       )
 end)
 
-let default_vdi_info = {
-  vdi = "";
-  uuid = None;
-  content_id = "";
-  name_label = "";
-  name_description = "";
-  ty = "user";
-  metadata_of_pool = "";
-  is_a_snapshot = false;
-  snapshot_time = "19700101T00:00:00Z";
-  snapshot_of = "";
-  read_only = false;
-  cbt_enabled = false;
-  virtual_size = 0L;
-  physical_utilisation = 0L;
-  persistent = true;
-  sm_config = [];
-}
+let default_vdi_info = Storage_interface.default_vdi_info

--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -266,7 +266,7 @@ module SR = struct
 	(** Functions which manipulate SRs *)
 
 	(** [create dbg sr name_label name_description device_config physical_size] creates an sr with id [sr] *)
-	external create : dbg:debug_info -> sr:sr -> name_label:string -> name_description:string -> device_config:(string * string) list -> physical_size:int64 -> unit = ""
+	external create : dbg:debug_info -> sr:sr -> name_label:string -> name_description:string -> device_config:(string * string) list -> physical_size:int64 -> (string * string) list = ""
 
 	(** [set_name_label sr new_name_label] updates the name_label of SR [sr]. *)
 	external set_name_label : dbg:debug_info -> sr:sr -> new_name_label:string -> unit = ""

--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -69,6 +69,7 @@ type vdi_info = {
     physical_utilisation: int64;
     (* xenstore_data: workaround via XenAPI *)
 	persistent: bool;
+    sharable: bool;
     sm_config: (string * string) list;
 }
 
@@ -88,6 +89,7 @@ let default_vdi_info = {
     virtual_size = 0L;
     physical_utilisation = 0L;
     persistent = true;
+    sharable = false;
     sm_config = [];
 }
 

--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -203,6 +203,8 @@ module Dynamic = struct
 
 end
 
+type uuid = string
+
 exception Backend_error_with_backtrace of (string * (string list)) (** name * params *)
 
 exception Sr_not_attached of string               (** error: SR must be attached to access VDIs *)
@@ -214,6 +216,7 @@ exception Cancelled of string
 exception Redirect of string option
 exception Sr_attached of string
 exception Unimplemented of string
+exception Activated_on_another_host of uuid
 exception Duplicated_key of string
 exception No_storage_plugin_for_sr of string
 exception Content_ids_do_not_match of (string * string)


### PR DESCRIPTION
This is part of the SMAPIv3 interface  change from `feature/REQ477/master` branch (that branch had 2 full nightlies run on it).

SMAPIv3 requires a uuid returned from SR.create, this PR together with the one for XAPI changes SMAPIv2 to allow for that (SMAPIv1 is not affected).
This is a breaking API change for SMAPIv3 plugins!

Also expose the `sharable` field to SMAPIv3 (required for the HA statefile and redolog), internally XAPI already tracked this field. SMAPIv1 looked in `sm-config` to find this out, no change there.

This PR needs to be merged together with these ones otherwise the build breaks:
xapi-project/sm-cli#26
xapi-project/xapi-storage#70
xapi-project/xapi-storage-script#56
https://github.com/xapi-project/xen-api/pull/3433

I've done a build of these changes separately on the internal branch `private/edvint/477-idl-part2`
 