### PR TITLE
[WiP] CP-26340: SR.probe changes

### DIFF
--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -118,9 +118,11 @@ type dp_stat_t = {
 
 let string_of_dp_stat_t (x: dp_stat_t) = Jsonrpc.to_string (rpc_of_dp_stat_t x)
 
+type device_config = (string * string) list
 type probe = {
-  srs: (string * sr_info) list; (* SRs we found *)
-  uris: string list; (* other uris we found which could be probed recursively *)
+  attachable: (device_config * sr_info) list; (* Attachable SRs we found *)
+  creatable: device_config list; (* Complete configurations that can be used to create an SR. *)
+  incomplete: device_config list; (* other configurations we found which could be probed recursively *)
 }
 
 type probe_result =

--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -120,14 +120,15 @@ let string_of_dp_stat_t (x: dp_stat_t) = Jsonrpc.to_string (rpc_of_dp_stat_t x)
 
 type device_config = (string * string) list
 type probe = {
-  attachable: (device_config * sr_info) list; (* Attachable SRs we found *)
-  creatable: device_config list; (* Complete configurations that can be used to create an SR. *)
-  incomplete: device_config list; (* other configurations we found which could be probed recursively *)
+  configuration: (string * string) list;
+  complete: bool;
+  sr: sr_info option;
+  extra_info: (string * string) list;
 }
 
 type probe_result =
   | Raw of string (* SMAPIv1 adapters return arbitrary data *)
-  | Probe of probe
+  | Probe of probe list
 
 module Mirror = struct
 	type id = string


### PR DESCRIPTION
SMAPIv3 returns a list of configurations:
* suitable for SR.attach together with sr_info
* suitable for SR.create
* suitable as further input to SR.probe (recursively)

SMAPIv1 is unaffected, it always returns a `Raw` result.

Has to be merged together with:
https://github.com/xapi-project/xapi-storage/pull/74
https://github.com/xapi-project/xapi-storage-script/pull/58
https://github.com/xapi-project/xen-api/pull/3477

This is meant for discussion, we should merge only after the `xapi-storage-plugins` implementation is done, and we've agreed how the final API should look like.

In particular the SMAPIv3 plugin returns this type:
https://github.com/xapi-project/xapi-storage/blob/feature/REQ477/probe/generator/lib/control.ml#L59-L74

Should we make it return something more similar to the type here in xcp-idl? And what should we do with `extra_info`, should we change the probed device_config type to:
```ocaml
type probed_device_config = {
  configuration: (string * string) list; (* plugin-specific configuration suitable for SR.create, SR.attach, SR.probe *)
  extra_info : (string * string) list; (* Additional plugin-specific information about this configuration, that might be of use for an API user. This can for example include the LUN or the WWPN." *)
}
```