### PR TITLE
network_interface: extend the abstract type declaration for compatibility with rpc 3.2.0

### DIFF
--- a/cluster/cluster_interface.ml
+++ b/cluster/cluster_interface.ml
@@ -100,7 +100,8 @@ type error =
 [@@deriving rpcty]
 
 module E = Error.Make(struct
-    type t = error [@@deriving rpcty]
+  type t = error [@@deriving rpcty]
+  let internal_error_of _ = None
   end)
 let err = E.error
 

--- a/lib/xcp_service.ml
+++ b/lib/xcp_service.ml
@@ -63,7 +63,7 @@ module Config_file = struct
 
 	(* Trim trailing whitespace from a line *)
 	let trim_trailing_ws line =
-		let re_ws = Re.compile (Re_emacs.re "[ \t]+$") in
+		let re_ws = Re.compile (Re.Emacs.re "[ \t]+$") in
 		try
 			let ofs = fst (Re.get_all_ofs (Re.exec re_ws line)).(0) in
 			String.sub line 0 ofs
@@ -77,7 +77,7 @@ module Config_file = struct
 		with Not_found -> line
 
 	let get_kv line =
-		let re = Re.compile (Re_emacs.re "\\([^=\\ \t]+\\)[\\ \t]*=[\\ \t]*\\(.*\\)") in
+		let re = Re.compile (Re.Emacs.re "\\([^=\\ \t]+\\)[\\ \t]*=[\\ \t]*\\(.*\\)") in
 		let get (x,y) = String.sub line x (y-x) in
 		try
 			match Re.get_all_ofs (Re.exec re line) with

--- a/network/network_interface.ml
+++ b/network/network_interface.ml
@@ -58,6 +58,8 @@ let prefixlen_to_netmask len =
 module Unix = struct
   include Unix
   let typ_of_inet_addr = Rpc.Types.Abstract ({
+      aname  = "inet_addr";
+      test_data = [];
       rpc_of = (fun t -> Rpc.String (Unix.string_of_inet_addr t));
       of_rpc = (function
           | Rpc.String s -> Ok (Unix.inet_addr_of_string s)


### PR DESCRIPTION
Don't merge until https://github.com/xapi-project/xs-opam/pull/236 has been merged and a new `xs-opam` released

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>