### PR TITLE
CA-273983: Add storage exn for VDI.list_changed_blocks

### DIFF
--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -206,7 +206,7 @@ end
 type uuid = string
 
 exception Backend_error_with_backtrace of (string * (string list)) (** name * params *)
-
+exception Vdis_on_different_srs of (vdi * vdi)    (** error: VDI.list_changed_blocks requires both VDIs on same SR *)
 exception Sr_not_attached of string               (** error: SR must be attached to access VDIs *)
 exception Vdi_does_not_exist of string            (** error: the VDI is unknown *)
 exception Illegal_transition of (Vdi_automaton.state * Vdi_automaton.state) (** This operation implies an illegal state transition *)


### PR DESCRIPTION
`VDI.list_changed_blocks` currently returns `Storage_interface.Internal_error("Storage_access.No_VDI")` for VDIs on different SRs, which is an unhelpful error message, so I added a specific exception for this case that returns the ID of the two VDIs.

Changes to address this issue:
1. [xcp-idl]: Add a storage exn
2. [[xapi](https://github.com/xapi-project/xen-api/pull/3516)]: Add an assertion to Xapi_vdi.list_changed_blocks to check both VDIs are on the same SR

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>