### PR TITLE
Review probe API changes for feature/REQ477/master

### DIFF
--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -118,9 +118,11 @@ type dp_stat_t = {
 
 let string_of_dp_stat_t (x: dp_stat_t) = Jsonrpc.to_string (rpc_of_dp_stat_t x)
 
+type device_config = (string * string) list
 type probe = {
-  srs: (string * sr_info) list; (* SRs we found *)
-  uris: string list; (* other uris we found which could be probed recursively *)
+  attachable: (device_config * sr_info) list; (* Attachable SRs we found *)
+  creatable: device_config list; (* Complete configurations that can be used to create an SR. *)
+  incomplete: device_config list; (* other configurations we found which could be probed recursively *)
 }
 
 type probe_result =

--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -98,6 +98,7 @@ let vdi_info_of_rpc rpc = Rpc.struct_extend rpc (rpc_of_vdi_info default_vdi_inf
 type sr_health = Healthy | Recovering
 
 type sr_info = {
+    sr_uuid: string option;
     name_label: string;
     name_description: string;
     total_space: int64;        (** total number of bytes on the storage substrate *)

--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -119,7 +119,6 @@ type dp_stat_t = {
 
 let string_of_dp_stat_t (x: dp_stat_t) = Jsonrpc.to_string (rpc_of_dp_stat_t x)
 
-type device_config = (string * string) list
 type probe = {
   configuration: (string * string) list;
   complete: bool;

--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -120,14 +120,15 @@ let string_of_dp_stat_t (x: dp_stat_t) = Jsonrpc.to_string (rpc_of_dp_stat_t x)
 
 type device_config = (string * string) list
 type probe = {
-  attachable: (device_config * sr_info) list; (* Attachable SRs we found *)
-  creatable: device_config list; (* Complete configurations that can be used to create an SR. *)
-  incomplete: device_config list; (* other configurations we found which could be probed recursively *)
+  configuration: (string * string) list;
+  complete: bool;
+  sr: sr_info option;
+  extra_info: (string * string) list;
 }
 
 type probe_result =
   | Raw of string (* SMAPIv1 adapters return arbitrary data *)
-  | Probe of probe
+  | Probe of probe list
 
 module Mirror = struct
 	type id = string


### PR DESCRIPTION
Depends on these PRs:
https://github.com/xapi-project/xapi-storage/pull/79
https://github.com/xapi-project/xapi-storage-script/pull/61
https://github.com/xapi-project/xen-api/pull/3535
https://github.com/xenserver/xenadmin/pull/2014

Tested on feature/REQ477/probe-1 branch, with internal SR 81989, 81990, 81991. No new failures (there are existing known bugs with multipath and HBA, but they are unrelated to probe and appear on master as well)

I think all the commits should be squashed into one, we've been through a few iterations of this API according to the commit history, but it is not worth retaining that since you need to update all 3 repos everytime.