### PR TITLE
Backport of fixups made while porting idl to the new rpclib/rpclib-legacy packages

### DIFF
--- a/rrd/jbuild
+++ b/rrd/jbuild
@@ -50,7 +50,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     rrd
     threads
     xcp
-    xcp_rrd_interface_types))
+    xcp.rrd.interface.types))
   (wrapped false)
   %s))
 
@@ -64,7 +64,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     rrd
     threads
     xcp
-    xcp_rrd_interface))
+    xcp.rrd.interface))
   (wrapped false)
   %s))
 

--- a/storage/jbuild
+++ b/storage/jbuild
@@ -50,7 +50,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     threads
     xapi-stdext-date
     xcp
-    xcp_storage_interface_types))
+    xcp.storage.interface.types))
   (wrapped false)
   %s))
 
@@ -58,14 +58,13 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
  ((name xcp_storage)
   (public_name xcp.storage)
   (flags (:standard -w -39 %s))
-  (modules (:standard \ storage_interface storage_test vdi_automaton))
+  (modules (:standard \ storage_interface storage_test vdi_automaton vdi_automaton_test))
   (libraries
    (rpclib
     threads
     xapi-stdext-date
     xcp
-    xcp_storage_interface
-    xcp_storage_interface_types))
+    xcp.storage.interface))
   (wrapped false)
   %s))
 
@@ -77,7 +76,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    (cmdliner
     oUnit
     xcp
-    xcp_storage))
+    xcp.storage))
   %s))
 
 (executable

--- a/storage/jbuild
+++ b/storage/jbuild
@@ -79,4 +79,17 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     xcp
     xcp_storage))
   %s))
+
+(executable
+ ((name vdi_automaton_test)
+  (flags (:standard -w -39))
+  (modules (vdi_automaton_test))
+  (libraries
+   (xcp.storage.interface.types))))
+
+(alias
+ ((name runtest)
+  (deps (vdi_automaton_test.exe))
+  (action (run ${<}))))
+
 |} (flags rewriters_ppx) coverage_rewriter (flags rewriters_camlp4) coverage_rewriter (flags rewriters_ppx) coverage_rewriter (flags rewriters_ppx) coverage_rewriter

--- a/storage/vdi_automaton.ml
+++ b/storage/vdi_automaton.ml
@@ -119,22 +119,3 @@ let ( - ) x y = match x, y with
 	| Attached RW,  Activated RW -> [ Activate, Attached RW ]
 	| _, _ -> raise (No_operation (x, y))
 
-(* For any state [s] and operation [o] where [s' = s + o],
-   [if s <> s' then s - s' = op] *)
-
-let all_pairs x y =
-	List.fold_left (fun acc x -> List.map (fun y -> x, y) y @ acc) [] x
-
-let test () =
-	List.iter
-		(fun (s, op) ->
-			try
-				let s' = s + op in
-				let op' = List.map fst (s - s') in
-				if s <> s' && [ op ] <> op'
-				then failwith (Printf.sprintf "s = %s; op = %s; s + op = %s; s - (s + op) = %s" 
-					(string_of_state s) (string_of_op op)
-					(string_of_state s')
-					(String.concat ", " (List.map string_of_op op')))
-			with Bad_transition(_, _) -> ()
-		) (all_pairs every_state every_op)

--- a/storage/vdi_automaton_test.ml
+++ b/storage/vdi_automaton_test.ml
@@ -1,0 +1,35 @@
+(*
+ * Copyright Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+open Vdi_automaton
+
+(* For any state [s] and operation [o] where [s' = s + o],
+   [if s <> s' then s - s' = op] *)
+
+let all_pairs x y =
+  List.fold_left (fun acc x -> List.map (fun y -> x, y) y @ acc) [] x
+
+let () =
+  List.iter
+    (fun (s, op) ->
+       try
+         let s' = s + op in
+         let op' = List.map fst (s - s') in
+         if s <> s' && [ op ] <> op'
+         then failwith (Printf.sprintf "s = %s; op = %s; s + op = %s; s - (s + op) = %s" 
+                          (string_of_state s) (string_of_op op)
+                          (string_of_state s')
+                          (String.concat ", " (List.map string_of_op op')))
+       with Bad_transition(_, _) -> ()
+    ) (all_pairs every_state every_op);
+    Printf.printf "Passed."

--- a/storage/vdi_automaton_test.ml
+++ b/storage/vdi_automaton_test.ml
@@ -11,7 +11,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-open Vdi_automaton
 
 (* For any state [s] and operation [o] where [s' = s + o],
    [if s <> s' then s - s' = op] *)
@@ -23,15 +22,16 @@ let () =
   List.iter
     (fun (s, op) ->
        try
-         let s' = s + op in
-         let op' = List.map fst (s - s') in
+         let s' = Vdi_automaton.(s + op) in
+         let op' = List.map fst Vdi_automaton.(s - s') in
          if s <> s' && [ op ] <> op' then
-           failwith (Printf.sprintf "s = %s; op = %s; s + op = %s; s - (s + op) = %s"
+           failwith Vdi_automaton.(
+             Printf.sprintf "s = %s; op = %s; s + op = %s; s - (s + op) = %s"
                           (string_of_state s)
                           (string_of_op op)
                           (string_of_state s')
                           (String.concat ", " (List.map string_of_op op')))
-       with Bad_transition(_, _) -> ()
+       with Vdi_automaton.Bad_transition(_, _) -> ()
     ) (all_pairs every_state every_op);
     Printf.printf "Passed."
 

--- a/storage/vdi_automaton_test.ml
+++ b/storage/vdi_automaton_test.ml
@@ -25,11 +25,13 @@ let () =
        try
          let s' = s + op in
          let op' = List.map fst (s - s') in
-         if s <> s' && [ op ] <> op'
-         then failwith (Printf.sprintf "s = %s; op = %s; s + op = %s; s - (s + op) = %s" 
-                          (string_of_state s) (string_of_op op)
+         if s <> s' && [ op ] <> op' then
+           failwith (Printf.sprintf "s = %s; op = %s; s + op = %s; s - (s + op) = %s"
+                          (string_of_state s)
+                          (string_of_op op)
                           (string_of_state s')
                           (String.concat ", " (List.map string_of_op op')))
        with Bad_transition(_, _) -> ()
     ) (all_pairs every_state every_op);
     Printf.printf "Passed."
+

--- a/xen/jbuild
+++ b/xen/jbuild
@@ -50,7 +50,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    (rpclib
     threads
     xcp
-    xcp_xen_interface_types))
+    xcp.xen.interface.types))
   (wrapped false)
   %s))
 
@@ -63,7 +63,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    (rpclib
     threads
     xcp
-    xcp_xen_interface))
+    xcp.xen.interface))
   (wrapped false)
   %s))
 |} (flags rewriters_ppx) coverage_rewriter (flags rewriters_camlp4) coverage_rewriter (flags rewriters_ppx) coverage_rewriter


### PR DESCRIPTION
With these the next necessary update will become an opam file update with a couple of library renames and nothing more