### PR TITLE
xcp.opam, {storage,xen}/jbuild: use the new rpc 5.0.0 and rpclib-legacy

### DIFF
--- a/storage/jbuild
+++ b/storage/jbuild
@@ -22,7 +22,7 @@ let coverage_rewriter =
   else
     ""
 
-let rewriters_camlp4 = ["rpclib.idl -syntax camlp4o"]
+let rewriters_camlp4 = ["rpclib_legacy.idl -syntax camlp4o"]
 let rewriters_ppx = ["ppx_deriving_rpc"; "ppx_sexp_conv"]
 
 let () = Printf.ksprintf Jbuild_plugin.V1.send {|

--- a/xcp.opam
+++ b/xcp.opam
@@ -21,7 +21,8 @@ depends: [
   "ounit" {>= "2.0.0"}
   "ppx_sexp_conv"
   "re"
-  "rpc" {>= "1.9.51"}
+  "rpc" {>= "5.0.0"}
+  "rpclib-legacy"
   "sexplib"
   "uri"
   "xapi-backtrace"

--- a/xen/jbuild
+++ b/xen/jbuild
@@ -16,7 +16,7 @@ let flags = function
     go ic ""
 
 let rewriters_ppx = ["ppx_deriving_rpc"; "ppx_sexp_conv"]
-let rewriters_camlp4 = ["rpclib.idl -syntax camlp4o"]
+let rewriters_camlp4 = ["rpclib_legacy.idl -syntax camlp4o"]
 
 let coverage_rewriter = ""
 (* (preprocess (pps)) doesn't work with camlp4 and  the other ppx derivers,


### PR DESCRIPTION
This has to go in with https://github.com/xapi-project/xs-opam/pull/266 and the other related PRs

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>