### PR TITLE
xcp-idl: port to safe-strings without changing the interface

### DIFF
--- a/lib/cohttp_posix_io.ml
+++ b/lib/cohttp_posix_io.ml
@@ -43,18 +43,18 @@ module Unbuffered_IO = struct
   let read_http_headers fd =
     let buf = Buffer.create 128 in
     (* We can safely read everything up to this marker: *)
-    let end_of_headers = (Bytes.of_string "\r\n\r\n") in
-    let tmp = Bytes.make (Bytes.length end_of_headers) '\000' in
+    let end_of_headers = "\r\n\r\n" in
+    let tmp = Bytes.make (String.length end_of_headers) '\000' in
     let module Scanner = struct
       type t = {
-        marker: bytes;
+        marker: string;
         mutable i: int;
       }
       let make x = { marker = x; i = 0 }
       let input x c =
-        if c = Bytes.get x.marker x.i then x.i <- x.i + 1 else x.i <- 0
-      let remaining x = Bytes.length x.marker - x.i
-      let matched x = x.i = Bytes.length x.marker
+        if c = String.get x.marker x.i then x.i <- x.i + 1 else x.i <- 0
+      let remaining x = String.length x.marker - x.i
+      let matched x = x.i = String.length x.marker
     end in
     let marker = Scanner.make end_of_headers in
 

--- a/lib/scheduler.ml
+++ b/lib/scheduler.ml
@@ -91,7 +91,7 @@ module Delay = struct
     mutex_execute x.m
       (fun () ->
          match x.pipe_in with
-         | Some fd -> ignore(Unix.write fd "X" 0 1)
+         | Some fd -> ignore(Unix.write fd (Bytes.of_string "X") 0 1)
          | None -> x.signalled <- true 	 (* If the wait hasn't happened yet then store up the signal *)
       )
 end

--- a/lib/xcp_client.ml
+++ b/lib/xcp_client.ml
@@ -112,12 +112,12 @@ let binary_rpc string_of_call response_of_string ?(srcstr="unset") ?(dststr="uns
 			output_string oc len;
 			output_string oc msg_buf;
 			flush oc;
-			let len_buf = String.make 16 '\000' in
+			let len_buf = Bytes.make 16 '\000' in
 			really_input ic len_buf 0 16;
-			let len = int_of_string len_buf in
-			let msg_buf = String.make len '\000' in
+			let len = int_of_string (Bytes.unsafe_to_string len_buf) in
+			let msg_buf = Bytes.make len '\000' in
 			really_input ic msg_buf 0 len;
-			let (response: Rpc.response) = response_of_string msg_buf in
+			let (response: Rpc.response) = response_of_string (Bytes.unsafe_to_string msg_buf) in
 			response
 		)
 

--- a/lib/xcp_service.ml
+++ b/lib/xcp_service.ml
@@ -495,7 +495,7 @@ let pidfile_write filename =
 		let pid = Unix.getpid () in
 		let buf =
 			string_of_int pid ^ "\n" 
-			|> Bytes.unsafe_of_string
+			|> Bytes.of_string
 		in
 		let len = Bytes.length buf in
 		if Unix.write fd buf 0 len <> len

--- a/lib/xcp_service.ml
+++ b/lib/xcp_service.ml
@@ -389,9 +389,9 @@ let http_handler call_of_string string_of_response process s =
 				debug "Failed to read content-length"
 			| Some content_length ->
 				let content_length = int_of_string content_length in
-				let request_txt = String.make content_length '\000' in
+				let request_txt = Bytes.make content_length '\000' in
 				really_input ic request_txt 0 content_length;
-				let rpc_call = call_of_string request_txt in
+				let rpc_call = call_of_string (Bytes.unsafe_to_string request_txt) in
 				debug "%s" (Rpc.string_of_call rpc_call);
 				let rpc_response = process rpc_call in
 				debug "   %s" (Rpc.string_of_response rpc_response);
@@ -493,8 +493,11 @@ let pidfile_write filename =
 	finally
 	(fun () ->
 		let pid = Unix.getpid () in
-		let buf = string_of_int pid ^ "\n" in
-		let len = String.length buf in
+		let buf =
+			string_of_int pid ^ "\n" 
+			|> Bytes.unsafe_of_string
+		in
+		let len = Bytes.length buf in
 		if Unix.write fd buf 0 len <> len
 		then failwith "pidfile_write failed")
 	(fun () -> Unix.close fd)

--- a/lib_test/idl_test_common.ml
+++ b/lib_test/idl_test_common.ml
@@ -23,7 +23,7 @@ let read_str filename =
   let s = Bytes.create n in
   really_input ic s 0 n;
   close_in ic;
-  s
+  Bytes.unsafe_to_string s
 
 open Idl
 

--- a/network/network_stats.ml
+++ b/network/network_stats.ml
@@ -90,7 +90,7 @@ module File_helpers = struct
     let rec fold acc = 
       let n = Unix.read fd block 0 block_size in
       (* Consider making the interface explicitly use Substrings *)
-      let s = if n = block_size then block else String.sub block 0 n in
+      let s = if n = block_size then (Bytes.to_string block) else Bytes.sub_string block 0 n in
       if n = 0 then acc else fold (f acc s) in
     fold start
 


### PR DESCRIPTION
In the few places where we use unsafe coercions, you can easily track the ownership of the bytes. They are always contained around the block that deals with them