### PR TITLE
[smapiv3 merge] Add new attach interface from SMAPIv3

### DIFF
--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -410,7 +410,7 @@ module VDI = struct
 	(** [attach task dp sr vdi read_write] returns the [params] for a given
 		[vdi] in [sr] which can be written to if (but not necessarily only if) [read_write]
 		is true.
-    This function is deprecated, and is only here to keep backward
+    @deprecated This function is deprecated, and is only here to keep backward
     compatibility with old xapis that call Remote.VDI.attach during SXM.
     Use the attach2 function instead. *)
 	external attach : dbg:debug_info -> dp:dp -> sr:sr -> vdi:vdi -> read_write:bool -> attach_info = ""

--- a/storage/storage_skeleton.ml
+++ b/storage/storage_skeleton.ml
@@ -66,6 +66,7 @@ module VDI = struct
   let set_persistent ctx ~dbg ~sr ~vdi ~persistent = u "VDI.set_persistent"
   let epoch_begin ctx ~dbg ~sr ~vdi ~persistent = ()
   let attach ctx ~dbg ~dp ~sr ~vdi ~read_write = u "VDI.attach"
+  let attach2 ctx ~dbg ~dp ~sr ~vdi ~read_write = u "VDI.attach2"
   let activate ctx ~dbg ~dp ~sr ~vdi = u "VDI.activate"
   let deactivate ctx ~dbg ~dp ~sr ~vdi = u "VDI.deactivate"
   let detach ctx ~dbg ~dp ~sr ~vdi = u "VDI.detach"


### PR DESCRIPTION
The return type of this new VDI.attach2 call is the same of that of the
Datapath.attach call in SMAPIv3. I've copied the types from SMAPIv3.
We cannot change the original VDI.attach call, because during SXM, older
xapis call Remote.VDI.attach, therefore changing it's return type would break
backward compatibility and SXM.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xapi-project/xcp-idl/229)
<!-- Reviewable:end -->
