### PR TITLE
Fix build with rpclib 5.8.0

### DIFF
--- a/lib_test/idl_test_common.ml
+++ b/lib_test/idl_test_common.ml
@@ -47,6 +47,9 @@ end
 (* Slightly annoyingly, both RPC modules have a slightly different signature. Fix it here *)
 module TJsonrpc : MARSHALLER = struct
   include Jsonrpc
+  (* there is a ?strict parameter, and the signature would not match *)
+  let of_string s = of_string s
+  let response_of_string r = response_of_string r
   let string_of_call call = string_of_call call
   let string_of_response response = string_of_response response
 end


### PR DESCRIPTION
jbuilder runtest was failing with:
```
File "xcp-idl/lib_test/idl_test_common.ml", line 48, characters 31-171:
Error: Signature mismatch:
      ...
      Values do not match:
        val response_of_string : ?strict:bool -> string -> Rpc.response
      is not included in
        val response_of_string : string -> Rpc.response
      File "xcp-idl/lib_test/idl_test_common.ml", line 42, characters 2-49:
        Expected declaration
      File "src/lib/jsonrpc.mli", line 26, characters 0-63:
        Actual declaration
```