### PR TITLE
[477 merge] CP-28132: VDI.attach2 interface and move to new rpclib

### DIFF
--- a/lib_test/idl_test_common.ml
+++ b/lib_test/idl_test_common.ml
@@ -47,6 +47,9 @@ end
 (* Slightly annoyingly, both RPC modules have a slightly different signature. Fix it here *)
 module TJsonrpc : MARSHALLER = struct
   include Jsonrpc
+  (* there is a ?strict parameter, and the signature would not match *)
+  let of_string s = of_string s
+  let response_of_string r = response_of_string r
   let string_of_call call = string_of_call call
   let string_of_response response = string_of_response response
 end

--- a/storage/jbuild
+++ b/storage/jbuild
@@ -46,7 +46,8 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (flags (:standard -w -39 %s))
   (modules (storage_interface))
   (libraries
-   (rpclib
+   (astring
+    rpclib
     threads
     xapi-stdext-date
     xcp
@@ -58,7 +59,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
  ((name xcp_storage)
   (public_name xcp.storage)
   (flags (:standard -w -39 %s))
-  (modules (:standard \ storage_interface storage_test vdi_automaton vdi_automaton_test))
+  (modules (:standard \ storage_interface storage_test vdi_automaton suite vdi_automaton_test))
   (libraries
    (rpclib
     threads
@@ -80,15 +81,17 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   %s))
 
 (executable
- ((name vdi_automaton_test)
+ ((name suite)
   (flags (:standard -w -39))
-  (modules (vdi_automaton_test))
+  (modules (suite vdi_automaton_test))
   (libraries
-   (xcp.storage.interface.types))))
+   (alcotest
+    xcp.storage.interface
+    xcp.storage.interface.types))))
 
 (alias
  ((name runtest)
-  (deps (vdi_automaton_test.exe))
+  (deps (suite.exe))
   (action (run ${<}))))
 
 |} (flags rewriters_ppx) coverage_rewriter (flags rewriters_camlp4) coverage_rewriter (flags rewriters_ppx) coverage_rewriter (flags rewriters_ppx) coverage_rewriter

--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -77,7 +77,6 @@ type implementation =
   | Nbd of nbd
 
 type backend = {
-  domain_uuid: string;
   implementations: implementation list;
 }
 

--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -36,13 +36,49 @@ type vdi = string
 (** Opaque identifier used by the client to identify a particular operation *)
 type debug_info = string
 
-(** The result of a successful VDI.attach: this information (eg) can be used to
-	connect a VBD backend to a VBD frontend *)
+(** The result of a successful call to the deprecated VDI.attach: this
+   information (eg) can be used to connect a VBD backend to a VBD frontend *)
 type attach_info = {
-	params : string;
-	o_direct: bool;
-	o_direct_reason : string;
-	xenstore_data : (string * string) list;
+       params : string;
+       o_direct: bool;
+       o_direct_reason : string;
+       xenstore_data : (string * string) list;
+}
+
+type xendisk = {
+  params: string; (** Put into the "params" key in xenstore *)
+
+  extra: (string * string) list;
+  (** Key-value pairs to be put into the "extra" subdirectory underneath the
+      xenstore backend *)
+
+  backend_type: string;
+}
+
+type block_device = {
+  path: string; (** Path to the block device *)
+}
+
+type file = {
+  path: string; (** Path to the raw file *)
+}
+
+type nbd = {
+  uri: string;
+  (** NBD URI of the form nbd:unix:<domain-socket>:exportname=<NAME> (this
+      format is used by qemu-system:
+      https://manpages.debian.org/stretch/qemu-system-x86/qemu-system-x86_64.1.en.html) *)
+}
+
+type implementation =
+  | XenDisk of xendisk
+  | BlockDevice of block_device
+  | File of file
+  | Nbd of nbd
+
+type backend = {
+  domain_uuid: string;
+  implementations: implementation list;
 }
 
 (** Uniquely identifies the contents of a VDI *)
@@ -257,8 +293,8 @@ module DP = struct
 	external destroy: dbg:debug_info -> dp:dp -> allow_leak:bool -> unit = ""
 
 
-	(** [attach_info task sr vdi dp]: returns the params of the dp (the return value of VDI.attach) *)
-	external attach_info: dbg:debug_info -> sr:sr -> vdi:vdi -> dp:dp -> attach_info = ""
+	(** [attach_info task sr vdi dp]: returns the params of the dp (the return value of VDI.attach2) *)
+	external attach_info: dbg:debug_info -> sr:sr -> vdi:vdi -> dp:dp -> backend = ""
 
 	(** [diagnostics ()]: returns a printable set of diagnostic information,
 		typically including lists of all registered datapaths and their allocated
@@ -373,8 +409,16 @@ module VDI = struct
 
 	(** [attach task dp sr vdi read_write] returns the [params] for a given
 		[vdi] in [sr] which can be written to if (but not necessarily only if) [read_write]
-		is true *)
+		is true.
+    @deprecated This function is deprecated, and is only here to keep backward
+    compatibility with old xapis that call Remote.VDI.attach during SXM.
+    Use the attach2 function instead. *)
 	external attach : dbg:debug_info -> dp:dp -> sr:sr -> vdi:vdi -> read_write:bool -> attach_info = ""
+
+	(** [attach task dp sr vdi read_write] returns the [params] for a given
+		[vdi] in [sr] which can be written to if (but not necessarily only if) [read_write]
+		is true *)
+	external attach2 : dbg:debug_info -> dp:dp -> sr:sr -> vdi:vdi -> read_write:bool -> backend = ""
 
 	(** [activate task dp sr vdi] signals the desire to immediately use [vdi].
 		This client must have called [attach] on the [vdi] first. *)

--- a/storage/storage_skeleton.ml
+++ b/storage/storage_skeleton.ml
@@ -66,6 +66,7 @@ module VDI = struct
   let set_persistent ctx ~dbg ~sr ~vdi ~persistent = u "VDI.set_persistent"
   let epoch_begin ctx ~dbg ~sr ~vdi ~persistent = ()
   let attach ctx ~dbg ~dp ~sr ~vdi ~read_write = u "VDI.attach"
+  let attach2 ctx ~dbg ~dp ~sr ~vdi ~read_write = u "VDI.attach2"
   let activate ctx ~dbg ~dp ~sr ~vdi = u "VDI.activate"
   let deactivate ctx ~dbg ~dp ~sr ~vdi = u "VDI.deactivate"
   let detach ctx ~dbg ~dp ~sr ~vdi = u "VDI.detach"

--- a/storage/suite.ml
+++ b/storage/suite.ml
@@ -1,0 +1,16 @@
+
+let test_parse_nbd_uri () =
+  let nbd = Storage_interface.{ uri = "nbd:unix:socket:exportname=disk" } in
+  Alcotest.(check (pair string string)) "correctly parsed NBD URI"
+    ("socket", "disk")
+    (Storage_interface.parse_nbd_uri nbd)
+
+let test_helpers =
+  [ "test_parse_nbd_uri", `Quick, test_parse_nbd_uri
+  ]
+
+let () =
+  Alcotest.run "Storage_interface unit tests"
+    [ "helpers", test_helpers
+    ; "VDI automaton", Vdi_automaton_test.tests
+    ]

--- a/storage/vdi_automaton_test.ml
+++ b/storage/vdi_automaton_test.ml
@@ -18,7 +18,7 @@
 let all_pairs x y =
   List.fold_left (fun acc x -> List.map (fun y -> x, y) y @ acc) [] x
 
-let () =
+let run () =
   List.iter
     (fun (s, op) ->
        try
@@ -35,3 +35,5 @@ let () =
     ) (all_pairs Vdi_automaton.every_state Vdi_automaton.every_op);
     Printf.printf "Passed."
 
+let tests =
+  [ "VDI automaton test", `Quick, run ]

--- a/xcp.opam
+++ b/xcp.opam
@@ -8,6 +8,7 @@ tags: [ "org:xapi-project" ]
 build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 build-test: ["jbuilder" "runtest" "-p" name]
 depends: [
+  "astring"
   "base-threads"
   "base-unix"
   "cmdliner"


### PR DESCRIPTION
This has been reviewed previously and had a nightly test run.

Has to be merged together with:
https://github.com/xapi-project/xcp-idl/pull/232
https://github.com/xapi-project/xapi-storage-script/pull/73
https://github.com/xapi-project/xapi-storage/pull/89
https://github.com/xapi-project/xen-api/pull/3645
https://github.com/xapi-project/xenopsd/pull/524
<specfile change>