### PR TITLE
CA-292641: Collect log messages from libs using Logs

### DIFF
--- a/lib/debug.ml
+++ b/lib/debug.ml
@@ -185,8 +185,11 @@ let logs_reporter =
   in
   let report src level ~over k msgf =
     let formatter ?header ?tags fmt =
+      let buf = Buffer.create 80 in
+      let buf_fmt = Format.formatter_of_buffer buf in
       let k _ =
-        let msg = Format.flush_str_formatter () in
+        Format.pp_print_flush buf_fmt ();
+        let msg = Buffer.contents buf in
         (* We map the Logs source name to the "brand", so we have to use the
            name of the Logs source when enabling/disabling it *)
         let brand = Logs.Src.name src in
@@ -194,7 +197,7 @@ let logs_reporter =
         over ();
         k ()
       in
-      Format.kfprintf k Format.str_formatter fmt
+      Format.kfprintf k buf_fmt fmt
     in
     msgf formatter
   in

--- a/lib/debug.ml
+++ b/lib/debug.ml
@@ -159,6 +159,54 @@ let output_log brand level priority s =
     Syslog.log (get_facility ()) level msg
   end
 
+let logs_reporter =
+  (* We convert Logs level to our own type to allow output_log to correctly
+     filter logs coming from libraries using Logs *)
+  let logs_to_syslog_level = function
+    (* In practice we only care about Syslog.Debug,Warning,Info,Err,
+       because these are the ones we use in the log functions in Debug.Make *)
+    | Logs.Debug -> Syslog.Debug
+    | Logs.Info -> Syslog.Info
+    | Logs.Warning -> Syslog.Warning
+    | Logs.Error -> Syslog.Err
+    (* This is used by applications, not libraries - we should not get this in practice *)
+    | Logs.App -> Syslog.Info
+  in
+  (* Ensure that logs from libraries will be displayed with the correct
+     priority *)
+  let logs_level_to_priority = function
+    (* These string match the ones used by the logging functions in Debug.Make *)
+    | Logs.Debug -> "debug"
+    | Logs.Info -> "info"
+    | Logs.Warning -> "warn"
+    | Logs.Error -> "error"
+    (* This is used by applications, not libraries - we should not get this in practice *)
+    | Logs.App -> "app"
+  in
+  let report src level ~over k msgf =
+    let formatter ?header ?tags fmt =
+      let k _ =
+        let msg = Format.flush_str_formatter () in
+        (* We map the Logs source name to the "brand", so we have to use the
+           name of the Logs source when enabling/disabling it *)
+        let brand = Logs.Src.name src in
+        output_log brand (logs_to_syslog_level level) (logs_level_to_priority level) msg;
+        over ();
+        k ()
+      in
+      Format.kfprintf k Format.str_formatter fmt
+    in
+    msgf formatter
+  in
+  { Logs.report = report }
+
+let init_logs () =
+  Logs.set_reporter logs_reporter;
+  (* [output_log] will do the actual filtering based on levels,
+     but we only consider messages of level warning and above from libraries,
+     to avoid calling [output_log] too often. *)
+  Logs.set_level (Some Logs.Warning)
+
 let rec split_c c str =
   try
     let i = String.index str c in

--- a/lib/debug.mli
+++ b/lib/debug.mli
@@ -17,6 +17,10 @@
 (** Throw away the cached hostname. The next log line will re-query the hostname *)
 val invalidate_hostname_cache: unit -> unit
 
+val init_logs : unit -> unit
+(** Register a Logs reporter to collect and report log messages from libraries
+    using Logs *)
+
 (** {2 Associate a task to the current actions} *)
 
 (** Do an action with a task name associated with the current thread *)

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -53,6 +53,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     cmdliner
     cohttp
     fd-send-recv
+    logs
     message-switch-core
     message-switch-unix
     ppx_deriving_rpc

--- a/lib/xcp_service.ml
+++ b/lib/xcp_service.ml
@@ -300,6 +300,9 @@ let startswith prefix x =
         prefix' <= x' && (String.sub x 0 prefix' = prefix)
 
 let configure_common ~options ~resources arg_parse_fn =
+	(* Register the Logs reporter to ensure we get log messages from libraries using Logs *)
+	Debug.init_logs ();
+
 	let resources = default_resources @ resources in
 	let config_spec = common_options @ options @ (to_opt resources) in
 

--- a/xcp.opam
+++ b/xcp.opam
@@ -15,6 +15,7 @@ depends: [
   "cohttp"
   "fd-send-recv" {>= "2.0.0"}
   "jbuilder" {build & >= "1.0+beta11"}
+  "logs"
   "message-switch-core"
   "message-switch-unix"
   "ocamlfind" {build}


### PR DESCRIPTION
We register our log reporter when an xcp service is configured, this way
we can report logs coming from libraries that use Logs. For example, we
can report errors in the cleanup function from stdext's finally.

For efficiency, we only consider logs of level warning and above from
libraries, to avoid calling our output_log function too often, which
does the actual filtering. It will be able to filter logs from libraries
too, the same way it filters them for toolstack components, because we
convert the Logs level and source to our own log level type and "brand".

Instead of using a shared Format.stbuf with str_formatter - this might
cause problems when logging from multiple threads - I decided to use a private buffer for the logs formatter.