### PR TITLE
UEFI: add fields for VM.start

### DIFF
--- a/xen/xenops_types.ml
+++ b/xen/xenops_types.ml
@@ -37,20 +37,20 @@ module Vgpu = struct
 
 end
 
-module Nvram = struct
+module Nvram_uefi_variables = struct
   type onboot =
     | Persist
     | Reset
     [@@deriving rpc, sexp]
 
   type t = {
-    efi_variables_on_boot: onboot;
-    efi_variables_backend: string;
+    on_boot: onboot;
+    backend: string;
   } [@@deriving rpc, sexp]
 
   let default_t = {
-    efi_variables_on_boot = Persist;
-    efi_variables_backend = "xapidb"
+    on_boot = Persist;
+    backend = "xapidb"
   }
 
   let t_of_rpc rpc =
@@ -72,7 +72,7 @@ module Vm = struct
 
   type firmware_type =
     | Bios
-    | Uefi
+    | Uefi of Nvram_uefi_variables.t
   [@@deriving rpc, sexp]
 
   let default_firmware = Bios
@@ -93,7 +93,6 @@ module Vm = struct
     qemu_disk_cmdline: bool;
     qemu_stubdom: bool;
     firmware: firmware_type;
-    nvram: Nvram.t;
   }
   [@@deriving rpc, sexp]
 
@@ -115,7 +114,6 @@ module Vm = struct
     qemu_disk_cmdline = false;
     qemu_stubdom = false;
     firmware = default_firmware;
-    nvram = Nvram.default_t;
   }
 
   let hvm_info_of_rpc rpc =

--- a/xen/xenops_types.ml
+++ b/xen/xenops_types.ml
@@ -70,6 +70,7 @@ module Vm = struct
     qemu_disk_cmdline: bool;
     qemu_stubdom: bool;
     firmware: firmware_type option;
+    nvram: (string * string) list option;
   }
   [@@deriving rpc, sexp]
 
@@ -91,6 +92,7 @@ module Vm = struct
     qemu_disk_cmdline = false;
     qemu_stubdom = false;
     firmware = None;
+    nvram = None;
   }
 
   type pv_direct_boot = {

--- a/xen/xenops_types.ml
+++ b/xen/xenops_types.ml
@@ -49,6 +49,11 @@ module Vm = struct
     | IGD_passthrough of igd_passthrough
   [@@deriving rpc, sexp]
 
+  type firmware_type =
+    | Bios
+    | Uefi
+  [@@deriving rpc, sexp]
+
   type hvm_info = {
     hap: bool;
     shadow_multiplier: float;
@@ -64,6 +69,7 @@ module Vm = struct
     boot_order: string;
     qemu_disk_cmdline: bool;
     qemu_stubdom: bool;
+    firmware: firmware_type option;
   }
   [@@deriving rpc, sexp]
 
@@ -84,6 +90,7 @@ module Vm = struct
     boot_order = "";
     qemu_disk_cmdline = false;
     qemu_stubdom = false;
+    firmware = None;
   }
 
   type pv_direct_boot = {


### PR DESCRIPTION
Needs to be merged together with:
https://github.com/xapi-project/xcp-idl/pull/234
https://github.com/xapi-project/xen-api/pull/3675
https://github.com/xapi-project/xenopsd/pull/536
https://github.com/xapi-project/xenops-cli/pull/25