### PR TITLE
Task/Updates: Remove dependence on camlp4 style interfaces

### DIFF
--- a/lib/task_server.mli
+++ b/lib/task_server.mli
@@ -11,14 +11,14 @@ type stringpair = string * string
 module type INTERFACE =
 sig
   val service_name : string
-  exception Does_not_exist of stringpair
-  exception Cancelled of string
+  val does_not_exist : stringpair -> exn
+  val cancelled : string -> exn
+  val marshal_exn : exn -> Rpc.t
+
   module Task :
   sig
     type id = string
     type async_result
-    val rpc_of_async_result : async_result -> Rpc.t
-    val async_result_of_rpc : Rpc.t -> async_result
     type completion_t = {
       duration : float;
       result : async_result option;
@@ -37,10 +37,6 @@ sig
       backtrace: string;
     }
   end
-  module Exception : sig type exnty val rpc_of_exnty : exnty -> Rpc.t end
-  val exnty_of_exn : exn -> Exception.exnty
-  val exn_of_exnty : Exception.exnty -> exn
-  exception Internal_error of string
 end
 
 module Task :

--- a/lib/updates.ml
+++ b/lib/updates.ml
@@ -10,7 +10,6 @@ module type INTERFACE = sig
   module Dynamic : sig
     type id
     val rpc_of_id : id -> Rpc.t
-    val id_of_rpc : Rpc.t -> id
   end
 end
 

--- a/lib/updates.mli
+++ b/lib/updates.mli
@@ -17,7 +17,7 @@ module type INTERFACE =
 sig
   val service_name : string
   module Dynamic :
-  sig type id val rpc_of_id : id -> Rpc.t val id_of_rpc : Rpc.t -> id end
+  sig type id val rpc_of_id : id -> Rpc.t end
 end
 
 module Updates :


### PR DESCRIPTION
The Task and Updates generic code used by both the xen and storage
interfaces requires the interface code to be structured in a way that
is specific to the code produced by the camlp4 idl. This commit
makes it a bit easier to transition to the ppx-based idl.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>