### PR TITLE
CA-290696: Add field cancellable for task

### DIFF
--- a/lib/task_server.mli
+++ b/lib/task_server.mli
@@ -35,6 +35,7 @@ sig
       subtasks: (string * state) list;
       debug_info: (string * string) list;
       backtrace: string;
+      cancellable: bool;
     }
   end
 end
@@ -100,4 +101,6 @@ module Task :
 
     (* Sets a cancellation function to be called if the task is cancelled *)
     val with_cancel : task_handle -> (unit -> unit) -> (unit -> 'a) -> 'a
+    (* Set a task not cancellable *)
+    val prohibit_cancellation: task_handle -> unit
   end

--- a/lib_test/task_server_test.ml
+++ b/lib_test/task_server_test.ml
@@ -27,6 +27,7 @@ module TestInterface = struct
       subtasks: (string * state) list;
       debug_info: (string * string) list;
       backtrace: string;
+      cancellable: bool;
     }
   end
 

--- a/storage/storage_interface.ml
+++ b/storage/storage_interface.ml
@@ -321,6 +321,7 @@ module Task = struct
     subtasks: (string * state) list;
     debug_info: (string * string) list;
     backtrace: string;
+		cancellable: bool;
   }  [@@deriving rpcty]
 end
 

--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -388,8 +388,9 @@ module Task = struct
     ; state: state
     ; subtasks: (string * state) list
     ; debug_info: (string * string) list
-    ; backtrace: string
-    (* An s-expression encoded Backtrace.t *) }
+    ; backtrace: string (* An s-expression encoded Backtrace.t *)
+    ; cancellable: bool
+    }
   [@@deriving rpcty]
 
   type t_list = t list [@@deriving rpcty]


### PR DESCRIPTION
Add a new field `cancellable` to Task. The default value is `true` which means
the task is cancellable.

Signed-off-by: Yang Qian <yang.qian@citrix.com>