### PR TITLE
Remove useless dependency rpclib-legacy

### DIFF
--- a/xcp.opam
+++ b/xcp.opam
@@ -23,7 +23,6 @@ depends: [
   "ppx_deriving_rpc"
   "ppx_sexp_conv"
   "re"
-  "rpclib-legacy"
   "rrd"
   "sexplib"
   "base-threads"

--- a/xen/jbuild
+++ b/xen/jbuild
@@ -16,7 +16,6 @@ let flags = function
     go ic ""
 
 let rewriters_ppx = ["ppx_deriving_rpc"; "ppx_sexp_conv"]
-let rewriters_camlp4 = ["rpclib_legacy.idl -syntax camlp4o"]
 
 let coverage_rewriter = ""
 (* (preprocess (pps)) doesn't work with camlp4 and  the other ppx derivers,


### PR DESCRIPTION
We no longer depends camlp4, so remove the dependency accordingly.

Signed-off-by: Yang Qian <yang.qian@citrix.com>