### PR TITLE
rpclib-legacy got removed from xs-opam

### DIFF
--- a/xcp.opam
+++ b/xcp.opam
@@ -23,7 +23,6 @@ depends: [
   "ppx_deriving_rpc"
   "ppx_sexp_conv"
   "re"
-  "rpclib-legacy"
   "rrd"
   "sexplib"
   "base-threads"


### PR DESCRIPTION
This got dropped from xs-opam already when dropping camlp4, but the opam file here was outdated.