### PR TITLE
Travis: test the xcp package not the dummy package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   global:
     - OCAML_VERSION=4.06
     - PINS="xcp:."
-    - PACKAGE=xapi-idl
+    - PACKAGE=xcp
     - DISTRO="debian-testing"
   matrix:
     - BASE_REMOTE=git://github.com/xapi-project/xs-opam \


### PR DESCRIPTION
opam2 only tests the packages you list, so it no longer tests xcp if you
ask it to test xapi-idl.

The test in this PR is expected to fail.