### PR TITLE
Register printer for Xmlm errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - OCAML_VERSION=4.06
     - PINS="xcp:."
     - PACKAGE=xcp
-    - DISTRO="debian-testing"
+    - DISTRO="debian-9"
   matrix:
     - BASE_REMOTE=git://github.com/xapi-project/xs-opam \
       POST_INSTALL_HOOK="env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID TEST_DEPS="alcotest" TEST_CMD='jbuilder runtest --no-buffer' bash -ex coverage.sh"

--- a/lib/xcp_client.ml
+++ b/lib/xcp_client.ml
@@ -100,6 +100,14 @@ let http_rpc string_of_call response_of_string ?(srcstr="unset") ?(dststr="unset
 let xml_http_rpc = http_rpc Xmlrpc.string_of_call Xmlrpc.response_of_string
 let json_switch_rpc queue_name = switch_rpc queue_name Jsonrpc.string_of_call Jsonrpc.response_of_string
 
+let () =
+  Printexc.register_printer (function
+    | Xmlm.Error ((line, col), error) ->
+        Some
+          (Printf.sprintf "Xmlm.Error(%d:%d, \"%s\")" line col
+             (Xmlm.error_message error))
+    | _ -> None )
+
 (* Use a binary 16-byte length to frame RPC messages *)
 let binary_rpc string_of_call response_of_string ?(srcstr="unset") ?(dststr="unset") url (call: Rpc.call) : Rpc.response =
 	let uri = Uri.of_string (url ()) in


### PR DESCRIPTION
It is much nicer to see `Xmlm.Error(1:1, "expected root element")`
than `Xmlm.Make(Buffer)(String).Error (_, -764030554)`.

I encountered the latter while setting up a new RPC server that wasn't replying with Xml properly on error, the better error message helped debugging the issue.