### PR TITLE
CA-302981, CP-30032: Add a timeout to varstored-guard RPC calls, sandbox varstore-rm

### DIFF
--- a/lib/xcp_client.ml
+++ b/lib/xcp_client.ml
@@ -31,10 +31,10 @@ let get_ok = function
       Format.pp_print_flush fmt ();
       failwith (Buffer.contents b)
 
-let switch_rpc queue_name string_of_call response_of_string =
+let switch_rpc ?timeout queue_name string_of_call response_of_string =
 	let t = get_ok (Message_switch_unix.Protocol_unix.Client.connect ~switch:!switch_path ()) in
 	fun call ->
-		response_of_string (get_ok (Message_switch_unix.Protocol_unix.Client.rpc ~t ~queue:queue_name ~body:(string_of_call call) ()))
+		response_of_string (get_ok (Message_switch_unix.Protocol_unix.Client.rpc ~t ?timeout ~queue:queue_name ~body:(string_of_call call) ()))
 
 let split_colon str =
   try
@@ -98,7 +98,7 @@ let http_rpc string_of_call response_of_string ?(srcstr="unset") ?(dststr="unset
 					end
 		)
 let xml_http_rpc = http_rpc Xmlrpc.string_of_call Xmlrpc.response_of_string
-let json_switch_rpc queue_name = switch_rpc queue_name Jsonrpc.string_of_call Jsonrpc.response_of_string
+let json_switch_rpc ?timeout queue_name = switch_rpc ?timeout queue_name Jsonrpc.string_of_call Jsonrpc.response_of_string
 
 let () =
   Printexc.register_printer (function

--- a/varstore/privileged/varstore_privileged_client.ml
+++ b/varstore/privileged/varstore_privileged_client.ml
@@ -15,7 +15,7 @@
 open Varstore_privileged_interface
 
 (* daemon only listens on message-switch *)
-let rpc call = Xcp_client.json_switch_rpc queue_name call
+let rpc call = Xcp_client.json_switch_rpc ~timeout:20 queue_name call
 
 module Client = RPC_API (Idl.Exn.GenClient (struct
   let rpc = rpc

--- a/varstore/privileged/varstore_privileged_interface.ml
+++ b/varstore/privileged/varstore_privileged_interface.ml
@@ -103,5 +103,5 @@ module RPC_API (R : RPC) = struct
     declare
       "destroy"
       ["Stop listening on sockets for the specified group"]
-      (debug_info_p @-> gid_p @-> returning unit_p err)
+      (debug_info_p @-> gid_p @-> path_p @-> returning unit_p err)
 end


### PR DESCRIPTION
If varstored-guard is not running we do not want to block the xenopsd/XAPI thread forever.
The API call here should just create/destroy a socket, therefore should be fairly "quick",
 20s ought to be more than enough even if the system is under high load.

We need the path parameter in stop, because the user id is no longer unique when we sandbox varstore-rm (there is no running domain associated with it).

