### PR TITLE
CA: 272180: Make xenopsd report the request that makes a shutdown to fail

### DIFF
--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -101,6 +101,7 @@ module Errors = struct
     | Invalid_vcpus of int
     | Bad_power_state of (power_state * power_state)
     | Failed_to_acknowledge_shutdown_request
+    | Failed_to_acknowledge_suspend_request
     | Failed_to_shutdown of (string * float)
     | Device_is_connected
     | Device_not_connected

--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -214,7 +214,7 @@ module Vgpu = struct
 
   type id = string * string [@@deriving rpcty]
 
-	let pci_default = Pci.{domain= 0; bus= 0; dev= 0; fn= 0}
+    let pci_default = Pci.{domain= 0; bus= 0; dev= 0; fn= 0}
   type t =
     { id: id [@default "", ""]
     ; position: int [@default 0]
@@ -479,7 +479,7 @@ module XenopsAPI (R : RPC) = struct
   let get_diagnostics =
     let result_p = Param.mk Rpc.Types.string in
     declare "get_diagnostics"
-		  ["Get diagnostics information from the backend"]
+          ["Get diagnostics information from the backend"]
       (debug_info_p @-> unit_p @-> returning result_p err)
 
   module TASK = struct

--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -103,6 +103,7 @@ module Errors = struct
     | Failed_to_acknowledge_shutdown_request
     | Failed_to_acknowledge_suspend_request
     | Failed_to_shutdown of (string * float)
+    | Failed_to_suspend of (string * float)
     | Device_is_connected
     | Device_not_connected
     | Device_detach_rejected of (string * string * string)

--- a/xen/xenops_types.ml
+++ b/xen/xenops_types.ml
@@ -41,7 +41,7 @@ module Nvram_uefi_variables = struct
   type onboot =
     | Persist
     | Reset
-    [@@deriving rpcty, sexp]
+  [@@deriving rpcty, sexp]
 
   type t = {
     on_boot: onboot [@default Persist];
@@ -87,7 +87,7 @@ module Vm = struct
     vnc_ip: string option [@default None];
     pci_emulations: string list [@default []];
     pci_passthrough: bool [@default false];
-    boot_order: string [@default ""]; 
+    boot_order: string [@default ""];
     qemu_disk_cmdline: bool [@default false];
     qemu_stubdom: bool [@default false];
     firmware: firmware_type [@default default_firmware];


### PR DESCRIPTION
Adding the shutdown request that failed allows xapi to inform the users better.

Also since the `shutdown_request` type is going to be used both in `xen-api` and `xenopsd`, add it here.