### PR TITLE
CP-30508: Expose iommu and hvm flags

### DIFF
--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -441,7 +441,7 @@ module Host = struct
     ; features_oldstyle: int64 array }
   [@@deriving rpcty]
 
-  type chipset_info = {iommu: bool} [@@deriving rpcty]
+  type chipset_info = {iommu: bool; hvm: bool} [@@deriving rpcty]
 
   type hypervisor = {version: string; capabilities: string} [@@deriving rpcty]
 

--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -441,9 +441,15 @@ module Host = struct
     ; features_oldstyle: int64 array }
   [@@deriving rpcty]
 
+  type chipset_info = {iommu: bool} [@@deriving rpcty]
+
   type hypervisor = {version: string; capabilities: string} [@@deriving rpcty]
 
-  type t = {cpu_info: cpu_info; hypervisor: hypervisor} [@@deriving rpcty]
+  type t =
+    { cpu_info: cpu_info
+    ; hypervisor: hypervisor
+    ; chipset_info: chipset_info }
+  [@@deriving rpcty]
 
   type guest_agent_feature =
     {name: string; licensed: bool; parameters: (string * string) list}


### PR DESCRIPTION
This allows xapi to retrieve the information from Xen instead of roundabout methods, increasing robustness.