### PR TITLE
CP-31321: Support extra_args for vGPU configuration

### DIFF
--- a/xen/xenops_types.ml
+++ b/xen/xenops_types.ml
@@ -31,6 +31,7 @@ module Vgpu = struct
     virtual_pci_address : Some {domain; bus; device; fn}
     type_id: 45
     uuid: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+    extra_args:key1=v1,key2=v2,key3=v3
   }
   *)
   type nvidia = {
@@ -39,6 +40,7 @@ module Vgpu = struct
     virtual_pci_address: address option;
     type_id: string;
     uuid: string;
+    extra_args: string; (* string is passed on as is and no structure is assumed *)
   } [@@deriving sexp, rpcty]
 
   type mxgpu = {


### PR DESCRIPTION
Signed-off-by: Lin Liu <lin.liu@citrix.com>

As titled, add support for extra_args for vgpu.

Customer can set extra args for the vgpu by command 
```xe vgpu-param-set uuid=xxxx extra_args="key1=v1,key2=v2"```
This is very similer to the previous verion of 
``` xe vm-param-set uuid=xxx platform:vgpu_extra_args="key1=v1,key2=v2"```