### PR TITLE
CA-322204: enable critical logging

### DIFF
--- a/lib/debug.ml
+++ b/lib/debug.ml
@@ -263,7 +263,7 @@ module type BRAND = sig
   val name: string
 end
 
-let all_levels = [Syslog.Debug; Syslog.Info; Syslog.Warning; Syslog.Err]
+let all_levels = [Syslog.Debug; Syslog.Info; Syslog.Warning; Syslog.Err; Syslog.Crit]
 
 let add_to_stoplist brand level =
   Hashtbl.replace logging_disabled_for (brand, level) ()
@@ -303,6 +303,8 @@ module type DEBUG = sig
 
   val error : ('a, unit, string, unit) format4 -> 'a
 
+  val critical : ('a, unit, string, unit) format4 -> 'a
+
   val audit : ?raw:bool -> ('a, unit, string, string) format4 -> 'a
 
   val log_backtrace : unit -> unit
@@ -326,6 +328,7 @@ module Make = functor(Brand: BRAND) -> struct
   let warn fmt = output Syslog.Warning "warn" fmt
   let info fmt = output Syslog.Info "info" fmt
   let error fmt = output Syslog.Err "error" fmt
+  let critical fmt = output Syslog.Crit "critical" fmt
   let audit ?(raw=false) (fmt: ('a, unit, string, 'b) format4) =
     Printf.kprintf
       (fun s ->

--- a/lib/debug.mli
+++ b/lib/debug.mli
@@ -84,6 +84,9 @@ module type DEBUG = sig
 	(** Error function *)
 	val error : ('a, unit, string, unit) format4 -> 'a
 
+	(** Critical function *)
+	val critical : ('a, unit, string, unit) format4 -> 'a
+
 	(** Audit function *)
 	val audit : ?raw:bool -> ('a, unit, string, string) format4 -> 'a
 

--- a/lib_test/debug_test.ml
+++ b/lib_test/debug_test.ml
@@ -1,90 +1,95 @@
 open OUnit
 
 
-let assert_levels brand (err, warn, info, debug) =
+let assert_levels brand (crit, err, warn, info, debug) =
+        assert_equal (Debug.is_disabled brand Syslog.Crit)    crit;
         assert_equal (Debug.is_disabled brand Syslog.Err)     err;
         assert_equal (Debug.is_disabled brand Syslog.Warning) warn;
         assert_equal (Debug.is_disabled brand Syslog.Info)    info;
         assert_equal (Debug.is_disabled brand Syslog.Debug)   debug
-  
+
 
 let test_default_levels () =
         Debug.reset_levels ();
 
-        assert_levels "some brand" (false, false, false, false);
-        assert_levels "some other brand" (false, false, false, false)
+        assert_levels "some brand" (false, false, false, false, false);
+        assert_levels "some other brand" (false, false, false, false, false)
 
 
 let test_debug_enable_disable () =
         Debug.reset_levels ();
 
         Debug.disable "xapi" ~level:Syslog.Info;
-        assert_levels "xapi" (false, false, true, false);
+        assert_levels "xapi" (false, false, false, true, false);
 
         Debug.enable "xapi" ~level:Syslog.Info;
-        assert_levels "xapi" (false, false, false, false)
+        assert_levels "xapi" (false, false, false, false, false)
 
 
 let test_debug_enable_disable_independent () =
         Debug.reset_levels ();
 
         Debug.enable "xapi" ~level:Syslog.Warning;
-        assert_levels "xapi" (false, false, false, false);
+        assert_levels "xapi" (false, false, false, false, false);
 
         Debug.disable "xenopsd" ~level:Syslog.Err;
-        assert_levels "xenopsd" (true, false, false, false);
-        assert_levels "xapi"    (false, false, false, false);
+        assert_levels "xenopsd" (false, true, false, false, false);
+        assert_levels "xapi"    (false, false, false, false, false);
 
         Debug.enable "xenopsd" ~level:Syslog.Err;
-        assert_levels "xenopsd" (false, false, false, false);
-        assert_levels "xapi"    (false, false, false, false)
+        assert_levels "xenopsd" (false, false, false, false, false);
+        assert_levels "xapi"    (false, false, false, false, false)
 
 
 let test_debug_set_level () =
         Debug.reset_levels ();
 
-        assert_levels "xapi"    (false, false, false, false);
-        assert_levels "other"   (false, false, false, false);
+        assert_levels "xapi"    (false, false, false, false, false);
+        assert_levels "other"   (false, false, false, false, false);
 
         Debug.set_level Syslog.Debug;
-        assert_levels "xapi"    (false, false, false, false);
-        assert_levels "other"   (false, false, false, false);
+        assert_levels "xapi"    (false, false, false, false, false);
+        assert_levels "other"   (false, false, false, false, false);
 
         Debug.set_level Syslog.Info;
-        assert_levels "xapi"    (false, false, false, true);
-        assert_levels "other"   (false, false, false, true);
+        assert_levels "xapi"    (false, false, false, false, true);
+        assert_levels "other"   (false, false, false, false, true);
 
         Debug.set_level Syslog.Warning;
-        assert_levels "xapi"    (false, false, true, true);
-        assert_levels "other"   (false, false, true, true);
+        assert_levels "xapi"    (false, false, false, true, true);
+        assert_levels "other"   (false, false, false, true, true);
 
         Debug.set_level Syslog.Err;
-        assert_levels "xapi"    (false, true, true, true);
-        assert_levels "other"   (false, true, true, true)
+        assert_levels "xapi"    (false, false, true, true, true);
+        assert_levels "other"   (false, false, true, true, true);
+
+        Debug.set_level Syslog.Crit;
+        assert_levels "xapi"    (false, true, true, true, true);
+        assert_levels "other"   (false, true, true, true, true)
 
 
-let test_debug_set_level_multiple_loggers () = 
+let test_debug_set_level_multiple_loggers () =
         let _ = (module Debug.Make(struct let name = "aaaa" end) : Debug.DEBUG) in
         let _ = (module Debug.Make(struct let name = "bbbb" end) : Debug.DEBUG) in
         Debug.reset_levels ();
 
-        assert_levels "aaaa"    (false, false, false, false);
-        assert_levels "bbbb"    (false, false, false, false);
+        assert_levels "aaaa"    (false, false, false, false, false);
+        assert_levels "bbbb"    (false, false, false, false, false);
 
         (* Set level explicitly on aaaa *)
         Debug.disable ~level:Syslog.Err "aaaa";
-        assert_levels "aaaa"    (true, false, false, false);
-        assert_levels "bbbb"    (false, false, false, false);
+        assert_levels "aaaa"    (false, true, false, false, false);
+        assert_levels "bbbb"    (false, false, false, false, false);
 
         (* Set default level.   Err should still be disabled for aaaa *)
         Debug.set_level Syslog.Warning;
-        assert_levels "aaaa"    (true, false, true, true);
-        assert_levels "bbbb"    (false, false, true, true)
+        assert_levels "aaaa"    (false, true, false, true, true);
+        assert_levels "bbbb"    (false, false, false, true, true)
 
 let tests =
   "debug" >:::
     [
-      "Test default levels" >:: test_default_levels; 
+      "Test default levels" >:: test_default_levels;
       "Test Debug.enable / disable" >:: test_debug_enable_disable;
       "Test Debug.enable / disable on different brands" >:: test_debug_enable_disable_independent;
       "Test Debug.set_level" >:: test_debug_set_level;

--- a/varstore/deprivileged/dune
+++ b/varstore/deprivileged/dune
@@ -5,7 +5,7 @@
   (flags (:standard -w -39))
   (libraries xcp threads rpclib.core xapi-idl.xen)
   (wrapped false)
-  (preprocess (pps ppx_deriving_rpc bisect_ppx -conditional)))
+  (preprocess (pps ppx_deriving_rpc)))
 
 (executable
   (name varstore_deprivileged_cli)

--- a/varstore/privileged/dune
+++ b/varstore/privileged/dune
@@ -5,7 +5,7 @@
   (flags (:standard -w -39))
   (libraries xcp threads rpclib.core)
   (wrapped false)
-  (preprocess (pps ppx_deriving_rpc bisect_ppx -conditional)))
+  (preprocess (pps ppx_deriving_rpc)))
 
 (executable
   (name varstore_privileged_cli)

--- a/xapi-idl.opam
+++ b/xapi-idl.opam
@@ -10,7 +10,7 @@ run-test: [[ "dune" "runtest" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
-  "alcotest"
+  "alcotest" {with-test}
   "astring"
   "cmdliner"
   "cohttp"
@@ -19,7 +19,7 @@ depends: [
   "message-switch-core"
   "message-switch-unix"
   "ocaml-migrate-parsetree"
-  "ounit"
+  "ounit" {with-test}
   "ppx_deriving_rpc"
   "ppx_sexp_conv"
   "re"


### PR DESCRIPTION
This permits synchronous logging in critical, edge-case situations when dom0 is properly configured.