### PR TITLE
CA-325843: Modify pv-shim (Xen 4.12) memory requirements

### DIFF
--- a/memory/memory.ml
+++ b/memory/memory.ml
@@ -134,7 +134,7 @@ end
 module PVinPVH_memory_model_data : MEMORY_MODEL_DATA = struct
   let extra_internal_mib = 1L
   let extra_external_mib = 1L
-  let shim_mib static_max_mib = 20L +++ (static_max_mib /// 110L)
+  let shim_mib static_max_mib = 20L +++ (static_max_mib /// 90L)
   let can_start_ballooned_down = false
 end
 


### PR DESCRIPTION
Current shim_mib calculation causes pv-shim to go out-of-memory and
panic for larger (>=8G) guests. The following memory usage has been
measured depending on the amount of guest RAM:

 RAM   shim
------------------------------------
128M   shim used   15M pages 0xfa1
256M   shim used   17M pages 0x11a0
512M   shim used   19M pages 0x13a0
  1G   shim used   25M pages 0x19a1
  2G   shim used   35M pages 0x23a0
  4G   shim used   54M pages 0x362e
  8G   shim used   98M pages 0x6277
 16G   shim used  187M pages 0xbb0b
 32G   shim used  364M pages 0x16c36
 64G   shim used  718M pages 0x2ce8a
128G   shim used 1429M pages 0x59532

Modify shim_mib formula in PVinPVH_memory_model_data accordingly.

Signed-off-by: Sergey Dyasli <sergey.dyasli@citrix.com>