### PR TITLE
CP-30428 Remove option from diagnostic.all_members

### DIFF
--- a/cluster/cluster_interface.ml
+++ b/cluster/cluster_interface.ml
@@ -75,7 +75,7 @@ type diagnostics = {
   next_cluster_config : cluster_config option; (* next corosync config *)
   saved_cluster_config : cluster_config option; (* xapi-clusterd DB *)
   is_enabled : bool;
-  all_members : all_members option;
+  all_members : all_members [@default []];
   node_id : nodeid option;
   token : string option;
   num_times_booted : int;


### PR DESCRIPTION
If we have a diagnostic, then there should always
be an all_members field, so it doesn't make sense
for it to be an option.

Signed-off-by: lippirk <ben.anson@citrix.com>