### PR TITLE
CA-326244: simplify host name cache and remove its lock

### DIFF
--- a/lib/debug.ml
+++ b/lib/debug.ml
@@ -24,44 +24,8 @@ module Mutex = struct
     r
 end
 
-module Cache = struct
-  type 'a t = {
-    mutable item: 'a option;
-    fn: unit -> 'a;
-    m: Mutex.t;
-  }
-
-  let make fn =
-    let item = None in
-    let m = Mutex.create () in
-    { item; fn; m }
-
-  let invalidate t =
-    Mutex.execute t.m
-      (fun () ->
-         t.item <- None;
-      )
-
-  let get t =
-    Mutex.execute t.m
-      (fun () ->
-         match t.item with
-         | Some x -> x
-         | None ->
-           let x = t.fn () in
-           t.item <- Some x;
-           x
-      )
-end
-
-let hostname = Cache.make
-    (fun () ->
-       let h = Unix.gethostname () in
-       Backtrace.set_my_name (Filename.basename(Sys.argv.(0)) ^ " @ " ^ h);
-       h
-    )
-
-let invalidate_hostname_cache () = Cache.invalidate hostname
+let hostname = ref (Unix.gethostname ())
+let invalidate_hostname_cache () = hostname := Unix.gethostname ()
 
 let get_thread_id () =
   try Thread.id (Thread.self ()) with _ -> -1
@@ -110,7 +74,7 @@ let gettimestring () =
     (int_of_float (1000.0 *. msec))
 
 let format include_time brand priority message =
-  let host = Cache.get hostname in
+  let host = !hostname in
   let id = get_thread_id () in
   let name = match ThreadLocalTable.find names with Some x -> x | None -> "" in
   let task = match ThreadLocalTable.find tasks with Some x -> x | None -> "" in


### PR DESCRIPTION
- To remove the locks from the host name cache I had to remove the call to
  Backtrace.set_my_name to include the host name in the backtrace name,
  however this is probably not very important because we can see the host
  name in the log line anyway.

  So
  1/1 xapi @ host-05-10 Raised at file
  would become
  1/1 xapi Raised at file

  I had to remove this call because I think otherwise we would need a lock
  when calling Backtrace.set_my_name to avoid race conditions.

- And I've simplified the host name cache so it does not use lazyness any
  more, but it gets the host name in the beginning once, and it
  refreshes it when it's invalidated.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>