### PR TITLE
CA-326244: do not include host name in log format

### DIFF
--- a/lib/debug.ml
+++ b/lib/debug.ml
@@ -77,7 +77,7 @@ let format include_time brand priority message =
   let name = match ThreadLocalTable.find names with Some x -> x | None -> "" in
   let task = match ThreadLocalTable.find tasks with Some x -> x | None -> "" in
 
-  Printf.sprintf "[%s%5s|%d %s|%s|%s] %s"
+  Printf.sprintf "[%s%5s||%d %s|%s|%s] %s"
     (if include_time then gettimestring () else "")
     priority id name task brand message
 

--- a/lib/debug.mli
+++ b/lib/debug.mli
@@ -12,10 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-(** Debug utilities *)
-
-(** Throw away the cached hostname. The next log line will re-query the hostname *)
-val invalidate_hostname_cache: unit -> unit
+(** {2 Debug utilities} *)
 
 val init_logs : unit -> unit
 (** Register a Logs reporter to collect and report log messages from libraries


### PR DESCRIPTION
Syslog outputs it anyway, so it is pointless to include it twice in the
log line, and it complicates the Debug module of xcp-idl.

This removes a lock that we always took when outputting a log line.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>