### PR TITLE
CA-327265: Modify shim_mib formula for Xen 4.13

### DIFF
--- a/memory/memory.ml
+++ b/memory/memory.ml
@@ -134,7 +134,7 @@ end
 module PVinPVH_memory_model_data : MEMORY_MODEL_DATA = struct
   let extra_internal_mib = 1L
   let extra_external_mib = 1L
-  let shim_mib static_max_mib = 20L +++ (static_max_mib /// 90L)
+  let shim_mib static_max_mib = 23L +++ (static_max_mib /// 90L)
   let can_start_ballooned_down = false
 end
 


### PR DESCRIPTION
Xen 4.12 --> 4.13 update makes pv-shim to use slightly more memory.
Modify the formula for shim_mib accordingly. Refer to the below table.

---------------------------------------
Guest    shim    curr     shim    new
 RAM     4.12   formula   4.13  formula
---------------------------------------
 128M     15M     21M     22M     24M
 256M     17M     22M     24M     25M
 512M     19M     25M     26M     28M
   1G     25M     31M     32M     34M
   2G     35M     42M     42M     45M
   4G     54M     65M     61M     68M
   8G     98M    111M    107M    114M
  16G    187M    202M    198M    205M
  32G    364M    384M    379M    387M
  64G    718M    748M    743M    751M
 128G   1429M   1476M   1472M   1479M

Signed-off-by: Sergey Dyasli <sergey.dyasli@citrix.com>