### PR TITLE
REQ-627 CA-328215 introduce pci_passthrough for PV

### DIFF
--- a/xen/xenops_types.ml
+++ b/xen/xenops_types.ml
@@ -135,6 +135,7 @@ module Vm = struct
     framebuffer_ip: string option [@default None];
     vncterm: bool [@default true];
     vncterm_ip: string option [@default None];
+    pci_passthrough: bool [@default false]
   }
   [@@deriving rpcty, sexp]
 


### PR DESCRIPTION
Xen 4.13 needs to know ahead of time when a domain is going to use PCI
passtrough. This information needs to be conveyed to xenopsd. This
commit introduces the flag in the PV domain build information passed
from Xapi to Xenopsd. Such a flag already exists for HVM guests.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>