### PR TITLE
CP-32446: Introduce Xen.features_pv_host and Xen.features_hvm_host

### DIFF
--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -440,6 +440,8 @@ module Host = struct
     ; features: int64 array
     ; features_pv: int64 array
     ; features_hvm: int64 array
+    ; features_pv_host: int64 array
+    ; features_hvm_host: int64 array
     ; features_oldstyle: int64 array }
   [@@deriving rpcty]
 


### PR DESCRIPTION
The existing `features_hvm` and `features_pv` will continue to report
migration-safe CPUID flags.

The new fields will report the pool-leveling and VM boot-time CPUID flags.

There are certain CPUID features that are not present on the host, but still work
after a migration, albeit slowly: these will be present in `features_hvm`,
but absent from `features_hvm_host`.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>