### PR TITLE
Documentation cleanup

### DIFF
--- a/cluster/cluster_interface.ml
+++ b/cluster/cluster_interface.ml
@@ -6,16 +6,16 @@ let service_name = "cluster"
 let queue_name = Xcp_service.common_prefix ^ service_name
 let json_path = "/var/xapi/cluster.json"
 
+(** An uninterpreted string associated with the operation. *)
 type debug_info = string
-[@@doc ["An uninterpreted string associated with the operation."]]
 [@@deriving rpcty]
 
+(** Name of the cluster *)
 type cluster_name = string
-[@@doc ["Name of the cluster"]]
 [@@deriving rpcty]
 
+(** An IPv4 address (a.b.c.d) *)
 type address = IPv4 of string
-[@doc ["An IPv4 address (a.b.c.d)"]]
 [@@deriving rpcty]
 let printaddr () = function | IPv4 s -> Printf.sprintf "IPv4(%s)" s
 let str_of_address address = match address with IPv4 a -> a
@@ -27,30 +27,33 @@ type start = bool [@@deriving rpcty]
 
 let string_of_nodeid = Int32.to_string
 
+(** This type describes an individual node in the cluster. It must have
+    a unique identity (an int32), and may have multiple IPv4 addresses on
+    which it can be contacted. *)
 type node = {
   addr: address;
   id: nodeid;
 }
-[@@doc
-  ["This type describes an individual node in the cluster. It must have";
-   "a unique identity (an int32), and may have multiple IPv4 addresses on";
-   "which it can be contacted."]]
 [@@deriving rpcty]
 
 type all_members = node list [@@deriving rpcty]
 
+(** This type contains all of the information required to initialise
+    the cluster. All optional params will have the recommended defaults
+    if None. *)
 type init_config = {
   local_ip : address;
   token_timeout_ms : int64 option;
   token_coefficient_ms : int64 option;
   name : string option;
 }
-[@@doc
-  ["This type contains all of the information required to initialise";
-   "the cluster. All optional params will have the recommended defaults";
-   "if None"]]
 [@@deriving rpcty]
 
+(** This type contains all of the information required to configure
+    the cluster. This includes all details required for the corosync
+    configuration as well as anything else required for pacemaker and
+    SBD. All nodes have a local copy of this and we take pains to
+    ensure it is kept in sync. *)
 type cluster_config = {
   cluster_name : string;
   enabled_members : node list;
@@ -59,16 +62,13 @@ type cluster_config = {
   cluster_token_timeout_ms : int64;
   cluster_token_coefficient_ms : int64;
 }
-[@@doc
-  ["This type contains all of the information required to configure";
-   "the cluster. This includes all details required for the corosync";
-   "configuration as well as anything else required for pacemaker and";
-   "SBD. All nodes have a local copy of this and we take pains to";
-   "ensure it is kept in sync."]]
 [@@deriving rpcty]
 
 type cluster_config_and_all_members = cluster_config * all_members [@@deriving rpcty]
 
+(** This type contains diagnostic information about the current state
+    of the cluster daemon. All state required for test purposes should
+    be in this type. *)
 type diagnostics = {
   config_valid : bool;
   live_cluster_config : cluster_config option; (* live corosync config *)
@@ -83,14 +83,10 @@ type diagnostics = {
   is_running : bool;
   startup_finished : bool;
 }
-[@@doc
- [ "This type contains diagnostic information about the current state";
-   "of the cluster daemon. All state required for test purposes should";
-   "be in this type."]]
 [@@deriving rpcty]
 
+(** This secret token is used to authenticate remote API calls on a cluster *)
 type token = string
-[@@doc ["This secret token is used to authenticate remote API calls on a cluster"]]
 [@@deriving rpcty]
 
 let token_p = Param.mk ~name:"token" token

--- a/lib/cohttp_posix_io.ml
+++ b/lib/cohttp_posix_io.ml
@@ -16,7 +16,7 @@
  *)
 
 module Unbuffered_IO = struct
-  (** Use as few Unix.{read,write} calls as we can (for efficiency) without
+  (** Use as few Unix.\{read,write\} calls as we can (for efficiency) without
       explicitly buffering the stream beyond the HTTP headers. This will
       allow us to consume the headers and then pass the file descriptor
       safely to another process *)
@@ -76,7 +76,7 @@ module Unbuffered_IO = struct
 
 
   (* Raises Not_found if there's no crlf *)
-  let rec find_crlf str from = 
+  let rec find_crlf str from =
     let cr = String.index_from str from '\r' in
     let lf = String.index_from str cr '\n' in
     if lf=cr+1 then cr else find_crlf str cr

--- a/memory/memory_interface.ml
+++ b/memory/memory_interface.ml
@@ -25,54 +25,41 @@ let queue_name = Xcp_service.common_prefix ^ service_name
 let json_path = "/var/xapi/memory.json"
 let xml_path = "/var/xapi/memory"
 
-type reservation_id =
-  string [@@doc [
-  "The reservation_id is an opaque identifier associated with a block of ";
-  "memory. It is used to reserve memory for a domain before the domain has ";
-  "been created.";
-]]
+(** The reservation_id is an opaque identifier associated with a block of
+    memory. It is used to reserve memory for a domain before the domain has
+    been created. *)
+type reservation_id = string
 [@@deriving rpcty]
 
+(** Domain zero can have a different policy to that used by guest domains. *)
 type domain_zero_policy =
-  | Fixed_size of int64 [@doc ["Never balloon, use the specified fixed size"]]
-  | Auto_balloon of int64 * int64 [@doc ["Balloon between the two sizes specified"]]
-[@@doc ["Domain zero can have a different policy to that used by guest domains."]]
+  | Fixed_size of int64 (** Never balloon, use the specified fixed size *)
+  | Auto_balloon of int64 * int64 (** Balloon between the two sizes specified *)
 [@@deriving rpcty]
 
 type errors =
   | Cannot_free_this_much_memory of (int64 * int64)
-        [@doc [
-          "[Cannot_free_this_much_memory (required, free)] is reported if it is not ";
-          "possible to free [required] kib. [free] is the amount of memory currently free"]]
+    (** [Cannot_free_this_much_memory (required, free)] is reported if it is not
+        possible to free [required] kib. [free] is the amount of memory
+        currently free. *)
   | Domains_refused_to_cooperate of (int list)
-        [@doc [
-          "[Domains_refused_to_cooperate (domid list)] is reported if a set of domains do ";
-          "not respond in a timely manner to the request to balloon. The uncooperative ";
-          "domain ids are returned."]]
+    (** [Domains_refused_to_cooperate (domid list)] is reported if a set of
+        domains do not respond in a timely manner to the request to balloon.
+        The uncooperative domain ids are returned. *)
   | Unknown_reservation of (reservation_id)
-        [@doc [
-          "[Unknown_reservation (id)] is reported if a the specified reservation_id is ";
-          "unknown."
-        ]]
+    (** [Unknown_reservation (id)] is reported if a the specified
+        reservation_id is unknown. *)
   | No_reservation
-      [@doc [
-        "[No_reservation] is reported by [query_reservation_of_domain] if the domain ";
-        "does not have a reservation."
-      ]]
+    (** [No_reservation] is reported by [query_reservation_of_domain] if the
+        domain does not have a reservation. *)
   | Invalid_memory_value of (int64)
-        [@doc [
-          "[Invalid_memory_value (value)] is reported if a memory value passed is not ";
-          "valid, e.g. negative."
-        ]]
+    (** [Invalid_memory_value (value)] is reported if a memory value passed is
+        not valid, e.g. negative. *)
   | Internal_error of (string)
-        [@doc [
-          "[Internal_error (value)] is reported if an unexpected error is triggered ";
-          "by the library."
-        ]]
+    (** [Internal_error (value)] is reported if an unexpected error is
+        triggered by the library. *)
   | Unknown_error
-      [@doc [
-        "The default variant for forward compatibility."
-      ]]
+    (** The default variant for forward compatibility. *)
 [@@default Unknown_error]
 [@@deriving rpcty]
 
@@ -104,15 +91,13 @@ let err = Error.
             Some (Internal_error (Printexc.to_string exn)))
     }
 
+(** An uninterpreted string associated with the operation. *)
 type debug_info = string
-[@@doc ["An uninterpreted string associated with the operation."]]
 [@@deriving rpcty]
 
+(** An identifier to associate requests with a client. This is
+    obtained by a call to [login]. *)
 type session_id = string
-[@@doc [
-  "An identifier to associate requests with a client. This is ";
-  "obtained by a call to [login]."
-]]
 [@@deriving rpcty]
 
 type reserve_memory_range_result = reservation_id * int64

--- a/varstore/privileged/varstore_privileged_interface.ml
+++ b/varstore/privileged/varstore_privileged_interface.ml
@@ -13,12 +13,12 @@
  *)
 
 (** Varstored is deprivileged and should not have full access to XAPI.
- ** This interface provides a way to spawn a new listening socket
- ** restricted to a small number of API calls targeting only 1 VM.
- ** Xenopsd is a client of this interface and calls it through message-switch.
- ** A new privileged daemon (varstored-socket-deprivd) implements the interface
- ** and spawns the listening sockets.
- ***)
+    This interface provides a way to spawn a new listening socket
+    restricted to a small number of API calls targeting only 1 VM.
+    Xenopsd is a client of this interface and calls it through message-switch.
+    A new privileged daemon (varstored-socket-deprivd) implements the interface
+    and spawns the listening sockets.
+   *)
 
 open Rpc
 open Idl
@@ -73,8 +73,9 @@ module RPC_API (R : RPC) = struct
 
   let implementation = implement description
 
+  (** An uninterpreted string associated with the operation. *)
   type debug_info = string
-  [@@doc ["An uninterpreted string associated with the operation."]] [@@deriving rpcty]
+  [@@deriving rpcty]
 
   let debug_info_p =
     Param.mk


### PR DESCRIPTION
Documentation in some places was annotated in strange ways which made upset odoc. ocaml-rpc should be compatible with ocamldoc's tags (https://github.com/mirage/ocaml-rpc/issues/139#issuecomment-562201548)

All the comments looked in the right place when I inspected the generated docs.