### PR TITLE
maintenance: replace references to pervasives module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: c
 sudo: required
 service: docker
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+  - wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env
+  - source xs-opam-ci.env
 script: bash -ex .travis-docker.sh
 env:
   global:
     - PACKAGE=xapi-idl
     - PINS="xapi-idl:."
-    - DISTRO="debian-unstable"
-    - OCAML_VERSION="4.07"
-    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"

--- a/lib/debug.ml
+++ b/lib/debug.ml
@@ -27,10 +27,7 @@ end
 let get_thread_id () =
   try Thread.id (Thread.self ()) with _ -> -1
 
-module IntMap = Map.Make(struct
-  type t = int
-  let compare = Pervasives.compare
-end)
+module IntMap = Map.Make(Int)
 
 module ThreadLocalTable = struct
   type 'a t = {
@@ -86,7 +83,7 @@ let log_to_stdout () = print_debug := true
 
 module BrandLevelPair = struct
   type t = string * Syslog.level
-  let compare = Pervasives.compare
+  let compare = Stdlib.compare
 end
 module BrandLevelPairSet = Set.Make(BrandLevelPair)
 


### PR DESCRIPTION
It's been markes as deprecated and throws warnings