### PR TITLE
CA-334912: Allow DMC in PV Shim

### DIFF
--- a/memory/memory.ml
+++ b/memory/memory.ml
@@ -135,7 +135,7 @@ module PVinPVH_memory_model_data : MEMORY_MODEL_DATA = struct
   let extra_internal_mib = 1L
   let extra_external_mib = 1L
   let shim_mib static_max_mib = 23L +++ (static_max_mib /// 90L)
-  let can_start_ballooned_down = false
+  let can_start_ballooned_down = true
 end
 
 type memory_config = {


### PR DESCRIPTION
Xenguest currently crashes in a less than obvious manner if target set less than static-max. This allows DMC instead, and the guest boots