### PR TITLE
dependency of xapi-project/xcp-networkd#173 - allow use of already enabled sr-iov virtual functions in xapi managed sr-iov networks

### DIFF
--- a/network/network_interface.ml
+++ b/network/network_interface.ml
@@ -651,6 +651,7 @@ module Interface_API(R : RPC) = struct
       | Modprobe_successful_requires_reboot
       | Modprobe_successful
       | Sysfs_successful
+      | Manual_successful
     [@@deriving rpcty]
 
     type enable_result =


### PR DESCRIPTION
The additions in this pull request are direct dependencies of xapi-project/xcp-networkd#173. Needed to allow the configuration/management of sr-iov networks in xapi, using adapters with already enabled sr-iov/vfs.

This pull request adds:
 * `Sriov.enable_action_result`: `Manual_successful`, for manual sr-iov/vf configuration support