### PR TITLE
Unrevert 'add Sriov.enable_action_result Manual_successful, for manual sr-iov/vf configuration support'

### DIFF
--- a/network/network_interface.ml
+++ b/network/network_interface.ml
@@ -722,6 +722,7 @@ module Interface_API (R : RPC) = struct
       | Modprobe_successful_requires_reboot
       | Modprobe_successful
       | Sysfs_successful
+      | Manual_successful
     [@@deriving rpcty]
 
     type enable_result = Ok of enable_action_result | Error of string


### PR DESCRIPTION
This needs to be merged together with https://github.com/xapi-project/xen-api/pull/4051