### PR TITLE
CP-34942: compatibility with rpclib 7 and 8

### DIFF
--- a/lib/xcp_client.ml
+++ b/lib/xcp_client.ml
@@ -24,9 +24,9 @@ let switch_path = ref "/var/run/message-switch/sock"
 let use_switch = ref true
 
 let get_ok = function
-  | `Ok x ->
+  | Ok x ->
       x
-  | `Error e ->
+  | Error e ->
       let b = Buffer.create 16 in
       let fmt = Format.formatter_of_buffer b in
       Message_switch_unix.Protocol_unix.Client.pp_error fmt e ;


### PR DESCRIPTION
There were two breaking changes affecting the tests:

- Avoiding marshalling integer as i8 requires the addition of the strict flag.
- A new function for json-rpc to have calls without responses got added

To test the changes I recommend to
* check out the xs-opam PR locally
* create a new opam switch and activate it
* add the local xs-opam repo to the switch with `opam repo add xs-opam-local location/to/xs-opam/folder`
* check out this PR and run `opam install --deps-only .` and `make test`

Depends on https://github.com/xapi-project/xs-opam/pull/511 and https://github.com/xapi-project/message-switch/pull/56