### PR TITLE
CP-35026 optionally include client info in logs

### DIFF
--- a/lib/debug.mli
+++ b/lib/debug.mli
@@ -20,7 +20,7 @@ val init_logs : unit -> unit
 
 (** {2 Associate a task to the current actions} *)
 
-val with_thread_associated : string -> ('a -> 'b) -> 'a -> 'b
+val with_thread_associated : ?client:string -> string -> ('a -> 'b) -> 'a -> 'b
 (** Do an action with a task name associated with the current thread *)
 
 (** {2 Associate a name to the current thread} *)


### PR DESCRIPTION
Allow callers of `with_thread_associated` to pass a client parameter which will be logged alongside a task's name