### PR TITLE
XSI-555/CA-347560: Add VM.import_metadata_async

### DIFF
--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -811,6 +811,13 @@ module XenopsAPI (R : RPC) = struct
         @-> Param.mk ~name:"metadata" Types.string
         @-> returning vm_id_p err
         )
+
+    let import_metadata_async =
+      declare "VM.import_metadata_async" []
+        (debug_info_p
+        @-> Param.mk ~name:"metadata" Types.string
+        @-> returning task_id_p err
+        )
   end
 
   module PCI = struct


### PR DESCRIPTION
This is a variant of `VM.import_metadata` that always queues the operation and
returns a task id immediately (like most VM operations). This is useful, once
the original (synchronous) function may block for longer periods while other
operations on the VM complete.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>