### PR TITLE
CA-347560: Add VM.import_metadata_async (Havana)

### DIFF
--- a/xen/xenops_interface.ml
+++ b/xen/xenops_interface.ml
@@ -436,6 +436,7 @@ module VM = struct
 
 	external export_metadata: debug_info -> Vm.id -> string  = ""
 	external import_metadata: debug_info -> string -> Vm.id  = ""
+	external import_metadata_async: debug_info -> string -> Task.id  = ""
 end
 
 module PCI = struct


### PR DESCRIPTION
Backport of 83de389b.

This is a variant of `VM.import_metadata` that always queues the operation and
returns a task id immediately (like most VM operations). This is useful, once
the original (synchronous) function may block for longer periods while other
operations on the VM complete.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>