### PR TITLE
Handle IPv6:

### DIFF
--- a/lib/posix_channel.ml
+++ b/lib/posix_channel.ml
@@ -207,9 +207,12 @@ let receive protocols =
   | V4V_proxy (_, _) ->
       assert false (* weight is 0 above *)
   | TCP_proxy (ip, port) -> (
-      let s = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+      let unwrapped_ip = Scanf.ksscanf ip (fun _ _ -> ip) "[%s@]" Fun.id in
+      let addr = Unix.ADDR_INET (Unix.inet_addr_of_string unwrapped_ip, port) in
+      let family = Unix.domain_of_sockaddr addr in
+      let s = Unix.socket family Unix.SOCK_STREAM 0 in
       try
-        Unix.connect s (Unix.ADDR_INET (Unix.inet_addr_of_string ip, port)) ;
+        Unix.connect s addr ;
         s
       with e -> Unix.close s ; raise e
     )

--- a/misc/channel_helper.ml
+++ b/misc/channel_helper.ml
@@ -86,9 +86,12 @@ let help =
 
 (* Commands *)
 let advertise_t _common_options_t proxy_socket =
-  let s_ip = Lwt_unix.socket Lwt_unix.PF_INET Lwt_unix.SOCK_STREAM 0 in
+  let unwrapped_ip = Scanf.ksscanf !ip (fun _ _ -> !ip) "[%s@]" Fun.id in
+  let addr = Lwt_unix.ADDR_INET (Unix.inet_addr_of_string unwrapped_ip, 0) in
+  let family = Lwt_unix.domain_of_sockaddr addr in
+  let s_ip = Lwt_unix.socket family Lwt_unix.SOCK_STREAM 0 in
   (* INET socket, can't block *)
-  Lwt_unix.bind s_ip (Lwt_unix.ADDR_INET (Unix.inet_addr_of_string !ip, 0))
+  Lwt_unix.bind s_ip addr
   >>= fun () ->
   Lwt_unix.listen s_ip 5 ;
   let port =

--- a/misc/channel_helper.ml
+++ b/misc/channel_helper.ml
@@ -88,7 +88,7 @@ let help =
 let advertise_t _common_options_t proxy_socket =
   let unwrapped_ip = Scanf.ksscanf !ip (fun _ _ -> !ip) "[%s@]" Fun.id in
   let addr = Lwt_unix.ADDR_INET (Unix.inet_addr_of_string unwrapped_ip, 0) in
-  let family = Lwt_unix.domain_of_sockaddr addr in
+  let family = Unix.domain_of_sockaddr addr in
   let s_ip = Lwt_unix.socket family Lwt_unix.SOCK_STREAM 0 in
   (* INET socket, can't block *)
   Lwt_unix.bind s_ip addr


### PR DESCRIPTION
- replace `gethostbyname` by `getaddrinfo`
- do not assume IPv4 for all addresses

This is a fixed version of https://github.com/xapi-project/xcp-idl/pull/321 that was reverted by https://github.com/xapi-project/xcp-idl/pull/325.

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>